### PR TITLE
Support alternate save path for screenshots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,27 @@ Capybara::Screenshot::Diff.enabled = ENV['COMPARE_SCREENSHOTS']
 
 ### Screen shot save path
 
-If you would like the screen shots to be saved in a different location set
+By default, `Capybara::Screenshot::Diff` saves screenshots to a
+`doc/screenshots` folder, relative to either `Rails.root` (if you're in Rails),
+ or your current directory otherwise.
+
+If you want to change where screenshots are saved to, then there are two
+configuration options that that are relevant.
+
+The most likely one you'll want to modify is ...
 
 ```ruby
-Capybara::Screenshot.save_path = "#{Rails.root}/doc/gui"
+Capybara::Screenshot::Diff.save_path = "other/path"
+```
+
+The `save_path` option is relative to `Capybara::Screenshot.root`.
+
+`Capybara::Screenshot.root` defaults to either `Rails.root` (if you're in
+Rails) or your current directory. You can change it to something entirely
+different if necessary, such as when using an alternative web framework.
+
+```ruby
+Capybara::Screenshot.root = Hanami.root
 ```
 
 ### Screen shot stability

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -13,6 +13,7 @@ module Capybara
     mattr_accessor(:root) { (defined?(Rails.root) && Rails.root) || File.expand_path('.') }
     mattr_accessor :stability_time_limit
     mattr_accessor :window_size
+    mattr_accessor(:save_path) { 'doc/screenshots' }
 
     class << self
       def active?
@@ -20,7 +21,7 @@ module Capybara
       end
 
       def screenshot_area
-        parts = ['doc/screenshots']
+        parts = [Capybara::Screenshot.save_path]
         parts << Capybara.current_driver.to_s if Capybara::Screenshot.add_driver_path
         parts << os_name if Capybara::Screenshot.add_os_path
         File.join parts

--- a/test/capybara/screenshot/diff_test.rb
+++ b/test/capybara/screenshot/diff_test.rb
@@ -43,6 +43,17 @@ module Capybara
         screenshot 'a'
       end
 
+      def test_screenshot_with_alternate_save_path
+        default_path = Capybara::Screenshot.save_path
+        Capybara::Screenshot.save_path = 'foo/bar'
+        screenshot_section 'a'
+        screenshot_group 'b'
+        screenshot 'a'
+        assert_match %r{foo/bar/rack_test/(macos|linux)/a/b}, screenshot_dir
+      ensure
+        Capybara::Screenshot.save_path = default_path
+      end
+
       def test_screenshot_with_stability_time_limit
         Capybara::Screenshot.stability_time_limit = 0.001
         screenshot 'a'


### PR DESCRIPTION
README previously suggested setting Capybara::Screenshot.save_path,
but Diff was actually hardcoded to use `doc/screenshot`.

However, Capybara::Screenshot doesn't have a `save_path` config option
anyway, and instead in it's README suggests setting
`Capybara.save_path`.  It seems completely reasonable though, that
users of Capybara::Screenshot::Diff would want screenshots saved to
someplace other than a tmp folder Capybara uses for `save_and_open_page`,
and visa-versa, so, this commit introduces the option, with the default
being the previously hardcoded path to maintain backwards compatability.