### PR TITLE
Support checking out old screenshots via LFS

### DIFF
--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -18,6 +18,7 @@ module Capybara
     mattr_accessor :stability_time_limit
     mattr_accessor :window_size
     mattr_accessor(:save_path) { 'doc/screenshots' }
+    mattr_accessor(:use_lfs)
 
     class << self
       def active?

--- a/lib/capybara/screenshot/diff/vcs.rb
+++ b/lib/capybara/screenshot/diff/vcs.rb
@@ -9,7 +9,12 @@ module Capybara
 
         def restore_git_revision(name, target_file_name)
           redirect_target = "#{target_file_name} #{SILENCE_ERRORS}"
-          `git show HEAD~0:./#{Capybara::Screenshot.screenshot_area}/#{name}.png > #{redirect_target}`
+          show_command = "git show HEAD~0:./#{Capybara::Screenshot.screenshot_area}/#{name}.png"
+          if Capybara::Screenshot.use_lfs
+            `#{show_command} | git lfs smudge > #{redirect_target}`
+          else
+            `#{show_command} > #{redirect_target}`
+          end
           FileUtils.rm_f(target_file_name) unless $CHILD_STATUS == 0
         end
 


### PR DESCRIPTION
If git-lfs is used to store screenshots, then this happens after running tests:

```
Error:
VisualsTest#test_0001_index:
ChunkyPNG::SignatureMismatch: PNG signature not found, found "version " instead of "\x89PNG\r\n\x1A\n"!
```

This is because `git show` on a file tracked by git-lfs doesn't actually give the real file contents, but a pointer to it:

```
% git show HEAD:doc/screenshots/home_page.png 
version https://git-lfs.github.com/spec/v1
oid sha256:bf62a87e2fd46bfd92b661e4128a3fc825e7c776d3ddab10fa124f255219dd39
size 677770
```

This patch is my first attempt to add optional LFS support. I've tested it and it works, but I'm not attached to the code nor the approach - I just needed something working ASAP to fix my build after I added LFS!

Additionally I want to mention that I found it surprising that this Gem uses Git at all. Is that strictly necessary? The files are on disk, so could that dependency be avoided by writing the new images somewhere else initially and comparing them?

If using Git is necessary, or you want to stick to that approach for other reasons, then I would like to propose mentioning the Git dependency in the Readme, as that was not obvious to me.