### PR TITLE
Remove dependency on JQuery for hiding the caret

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 136
+  Max: 144
 
 # Offense count: 10
 # Configuration parameters: IgnoredMethods.

--- a/lib/capybara/screenshot/diff/stabilization.rb
+++ b/lib/capybara/screenshot/diff/stabilization.rb
@@ -107,7 +107,13 @@ module Capybara
             JS
             blurred_input = page.driver.send :unwrap_script_result, active_element
           end
-          execute_script("$('*').css('caret-color','transparent')") if Capybara::Screenshot.hide_caret
+          hide_caret = <<~SCRIPT
+            var style = document.createElement('style');
+            document.head.appendChild(style);
+            var styleSheet = style.sheet;
+            styleSheet.insertRule("* { caret-color: transparent !important; }", 0);
+          SCRIPT
+          execute_script(hide_caret) if Capybara::Screenshot.hide_caret
           blurred_input
         end
 

--- a/lib/capybara/screenshot/diff/stabilization.rb
+++ b/lib/capybara/screenshot/diff/stabilization.rb
@@ -107,13 +107,15 @@ module Capybara
             JS
             blurred_input = page.driver.send :unwrap_script_result, active_element
           end
-          hide_caret = <<~SCRIPT
-            var style = document.createElement('style');
-            document.head.appendChild(style);
-            var styleSheet = style.sheet;
-            styleSheet.insertRule("* { caret-color: transparent !important; }", 0);
-          SCRIPT
-          execute_script(hide_caret) if Capybara::Screenshot.hide_caret
+          if Capybara::Screenshot.hide_caret && !@hid_caret
+            execute_script(<<~JS)
+              var style = document.createElement('style');
+              document.head.appendChild(style);
+              var styleSheet = style.sheet;
+              styleSheet.insertRule("* { caret-color: transparent !important; }", 0);
+            JS
+            @hid_caret = true
+          end
           blurred_input
         end
 


### PR DESCRIPTION
### Summary

Remove dependency on jQuery in caret hiding code so it works on any website.

### Motivation

Enabling `Capybara::Screenshot.hide_caret = true` on my Rails app gave the following error:

```
Error:
VisualsTest#test_0001_index:
Selenium::WebDriver::Error::JavascriptError: javascript error: $ is not defined
  (Session info: chrome=86.0.4240.75)
    test/system/visuals_test.rb:9:in `block in <class:VisualsTest>'
```

This is because there is an undeclared dependency on jQuery for this feature, and my website does not have jQuery installed.

### Details

I've made an attempt to change this feature to not depend on jQuery. Please let me know what you think!

Of note is that this new behaviour is not 1:1 with the original. I believe the original visits every node in the DOM and applies a style to it, whereas this code declares the style once at the top level for all elements. It's possible that certain existing CSS styles could override this, but I went this route because it's simpler and I believe will be faster. If you'd prefer to preserve the existing behaviour I can take a shot at doing that without jQuery too, but I believe this approach should suffice in almost all cases (how often does anyone style the caret, let alone with `!important`?)