### PR TITLE
Fix error message when a stable screenshot cannot be taken

### DIFF
--- a/lib/capybara/screenshot/diff/stabilization.rb
+++ b/lib/capybara/screenshot/diff/stabilization.rb
@@ -144,9 +144,6 @@ module Capybara
             end
             previous_file = file_name
           end
-
-          fail("Could not get stable screenshot within #{max_wait_time}s\n" \
-                    "#{stabilization_images(comparison.new_file_name).join("\n")}")
         end
 
         def max_wait_time(shift_distance_limit, wait)


### PR DESCRIPTION
Without this patch:

```
Error:
VisualsTest#test_0003_results with resources page:
ArgumentError: wrong number of arguments (given 0, expected 2)
    test/system/visuals_test.rb:32:in `block in <class:VisualsTest>'
```

With this patch:

```
VisualsTest#test_0003_results with resources page:
RuntimeError: Could not get stable screenshot within 2s
/Users/zofrex/Code/ruby/hoarders_of_runeterra/doc/screenshots/results_filled_out_x01_1.3s_[752_282_752_282].png~
/Users/zofrex/Code/ruby/hoarders_of_runeterra/doc/screenshots/results_filled_out_x02_2.6s_[924_282_924_282].png~
    test/system/visuals_test.rb:32:in `block in <class:VisualsTest>'
```

I think it's fine to delete this line entirely because the same error message is printed out by `check_max_wait_time`, which is the only caller of `annotate_stabilization_images`.

I think it would be great if there was a test for this – you can delete this entire method and the tests will still pass – but I don't know how this could be tested. Willing to attempt to implement a test if you can suggest an approach!