### PR TITLE
Draw skip_areas + some fixes after trying to use master on a project

### DIFF
--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -14,7 +14,7 @@ module Capybara
     mattr_accessor :blur_active_element
     mattr_accessor :enabled
     mattr_accessor :hide_caret
-    mattr_reader(:root) { (defined?(Rails.root) && Rails.root) || Pathname(".") }
+    mattr_reader(:root) { (defined?(Rails.root) && Rails.root) || Pathname(".").expand_path }
     mattr_accessor :stability_time_limit
     mattr_accessor :window_size
     mattr_accessor(:save_path) { "doc/screenshots" }

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -14,7 +14,7 @@ module Capybara
     mattr_accessor :blur_active_element
     mattr_accessor :enabled
     mattr_accessor :hide_caret
-    mattr_reader(:root) { (defined?(Rails.root) && Rails.root) || "." }
+    mattr_reader(:root) { (defined?(Rails.root) && Rails.root) || Pathname(".") }
     mattr_accessor :stability_time_limit
     mattr_accessor :window_size
     mattr_accessor(:save_path) { "doc/screenshots" }

--- a/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
@@ -42,11 +42,11 @@ module Capybara
           end
 
           def add_black_box(_image, _region)
-            # noop
+            _image
           end
 
           def difference_level(_diff_mask, old_img, region)
-            size(region) / image_area_size(old_img)
+            size(region).to_f / image_area_size(old_img)
           end
 
           def image_area_size(old_img)
@@ -181,10 +181,10 @@ module Capybara
             true
           end
 
-          def draw_rectangles(images, left, top, right, bottom)
+          def draw_rectangles(images, (left, top, right, bottom), (r, g, b))
             images.map do |image|
               new_img = image.dup
-              new_img.rect(left - 1, top - 1, right + 1, bottom + 1, ChunkyPNG::Color.rgb(255, 0, 0))
+              new_img.rect(left - 1, top - 1, right + 1, bottom + 1, ChunkyPNG::Color.rgb(r, g, b))
               new_img
             end
           end

--- a/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
@@ -41,8 +41,8 @@ module Capybara
             raise NotImplementedError
           end
 
-          def add_black_box(_image, _region)
-            _image
+          def add_black_box(image, _region)
+            image
           end
 
           def difference_level(_diff_mask, old_img, region)

--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -136,11 +136,9 @@ module Capybara
             [image.width, image.height]
           end
 
-          RED_INK = [255, 0, 0, 255].freeze
-
-          def draw_rectangles(images, left, top, right, bottom)
+          def draw_rectangles(images, (left, top, right, bottom), rgba)
             images.map do |image|
-              image.draw_rect(RED_INK, left - 1, top - 1, right - left + 2, bottom - top + 2)
+              image.draw_rect(rgba, left - 1, top - 1, right - left + 2, bottom - top + 2)
             end
           end
 

--- a/lib/capybara/screenshot/diff/image_compare.rb
+++ b/lib/capybara/screenshot/diff/image_compare.rb
@@ -119,9 +119,15 @@ module Capybara
           File.delete(@annotated_new_file_name) if File.exist?(@annotated_new_file_name)
         end
 
+        DIFF_COLOR = [255, 0, 0, 255].freeze
+        SKIP_COLOR = [255, 192, 0, 255].freeze
+
         def annotate_and_save(images, region = difference_region)
-          annotated_old_img, annotated_new_img = driver.draw_rectangles(images, *region)
-          save(annotated_new_img, annotated_old_img, @annotated_new_file_name, @annotated_old_file_name)
+          annotated_images = driver.draw_rectangles(images, region, DIFF_COLOR)
+          @skip_area.to_a.flatten.each_slice(4) do |region|
+            annotated_images = driver.draw_rectangles(annotated_images, region, SKIP_COLOR)
+          end
+          save(*annotated_images, @annotated_new_file_name, @annotated_old_file_name)
         end
 
         def save(new_img, old_img, annotated_new_file_name, annotated_old_file_name)


### PR DESCRIPTION
I wanted to see which areas were skipped during comparison so I added an orange rectangle for each skip_area.

During testing on master in a real-world project I also found some bugs, mostly for ChunkyPNG.