### PR TITLE
Bug: undefined method with stability_time_limit: true

### DIFF
--- a/lib/capybara/screenshot/diff/test_methods.rb
+++ b/lib/capybara/screenshot/diff/test_methods.rb
@@ -78,7 +78,6 @@ module Capybara
 
           comparison = ImageCompare.new(file_name, nil, driver_options)
           checkout_vcs(name, comparison.old_file_name, comparison.new_file_name)
-          take_comparison_screenshot(comparison, crop, stability_time_limit, wait)
 
           return false unless comparison.old_file_exists?
 
@@ -86,6 +85,8 @@ module Capybara
           if driver_options[:skip_area]
             comparison.skip_area = calculate_skip_area(driver_options[:skip_area], crop)
           end
+
+          take_comparison_screenshot(comparison, crop, stability_time_limit, wait)
 
           (@test_screenshots ||= []) << [caller[skip_stack_frames], name, comparison]
 

--- a/test/capybara/screenshot/diff/test_methods_test.rb
+++ b/test/capybara/screenshot/diff/test_methods_test.rb
@@ -54,6 +54,10 @@ module Capybara
           assert_equal 'a', @test_screenshots[1][1]
         end
 
+        def test_skip_area_and_stability_time_limit
+          screenshot(:a, skip_area: [0, 0, 1, 1], stability_time_limit: true)
+        end
+
         private
 
         def our_screenshot(name, skip_stack_frames)


### PR DESCRIPTION
```
Minitest::UnexpectedError: NoMethodError: undefined method `to_top_left_corner_coordinates' for [150.0, 250.0, 890.0, 270.0]:Array

            memo.draw_rect([0, 0, 0, 0], *region.to_top_left_corner_coordinates, fill: true)
```