### PR TITLE
Adds RBS signatures to help IDE to find usages and potential errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   BUNDLE_GEMFILE: 'gemfiles/rails70_gems.rb'
-  FERRUM_PROCESS_TIMEOUT: '15'
+  FERRUM_PROCESS_TIMEOUT: '40'
   WD_CACHE_TIME: '864000' # 10 days
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /tmp/
 /test/fixtures/**/*.committed.png
 /test/fixtures/**/*.latest.png
+/vendor/sigs/
+/*_*.png

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 /test/fixtures/**/*.committed.png
 /test/fixtures/**/*.latest.png
 /vendor/sigs/
-/*_*.png

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,11 @@ Rake::TestTask.new("test:integration") do |t|
   t.libs << "lib"
   t.test_files = FileList["test/integration/**/*_test.rb"]
 end
+
+Rake::TestTask.new("test:signatures") do |t|
+  ENV["RBS_TEST_TARGET"] ||= "Capybara::Screenshot::Diff::*"
+
+  t.libs << "test"
+  t.ruby_opts << "-r rbs/test/setup"
+  t.test_files = FileList["test/**/*_test.rb"]
+end

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -36,7 +36,6 @@ module Capybara
         File.join parts
       end
 
-      # @return [Pathname] absolute path to the screenshot start directory
       def screenshot_area_abs
         root / screenshot_area
       end

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -36,6 +36,7 @@ module Capybara
         File.join parts
       end
 
+      # @return [Pathname] absolute path to the screenshot start directory
       def screenshot_area_abs
         root / screenshot_area
       end

--- a/lib/capybara/screenshot/diff/browser_helpers.rb
+++ b/lib/capybara/screenshot/diff/browser_helpers.rb
@@ -10,7 +10,7 @@ module Capybara
       end
 
       def selenium?
-        !!(current_capybara_driver_class <= Capybara::Selenium::Driver)
+        current_capybara_driver_class <= Capybara::Selenium::Driver
       end
 
       def window_size_is_wrong?

--- a/lib/capybara/screenshot/diff/browser_helpers.rb
+++ b/lib/capybara/screenshot/diff/browser_helpers.rb
@@ -10,7 +10,7 @@ module Capybara
       end
 
       def selenium?
-        current_capybara_driver_class <= Capybara::Selenium::Driver
+        !!(current_capybara_driver_class <= Capybara::Selenium::Driver)
       end
 
       def window_size_is_wrong?

--- a/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
@@ -258,18 +258,23 @@ module Capybara
 
             color_distance =
               color_distance_at(new_img, old_img, x, y, shift_distance_limit: @shift_distance_limit)
+
             if !@max_color_distance || color_distance > @max_color_distance
               @max_color_distance = color_distance
             end
-            color_matches = color_distance == 0 || (@color_distance_limit && @color_distance_limit > 0 &&
-              color_distance <= @color_distance_limit)
+
+            color_matches = color_distance == 0 ||
+              (!!@color_distance_limit && @color_distance_limit > 0 && color_distance <= @color_distance_limit)
+
             return color_matches if !@shift_distance_limit || @max_shift_distance == Float::INFINITY
 
+            # @type [Numeric]
             shift_distance = (color_matches && 0) ||
               shift_distance_at(new_img, old_img, x, y, color_distance_limit: @color_distance_limit)
             if shift_distance && (@max_shift_distance.nil? || shift_distance > @max_shift_distance)
               @max_shift_distance = shift_distance
             end
+
             color_matches
           end
 
@@ -289,10 +294,10 @@ module Capybara
               end_y = [y + shift_distance_limit, new_img.height - 1].min
               ys = (start_y..end_y).to_a
               new_pixels = xs.product(ys)
-              distances = new_pixels.map { |dx, dy|
-                new_color = new_img[dx, dy]
-                ChunkyPNG::Color.euclidean_distance_rgba(org_color, new_color)
-              }
+
+              distances = new_pixels.map do |dx, dy|
+                ChunkyPNG::Color.euclidean_distance_rgba(org_color, new_img[dx, dy])
+              end
               distances.min
             else
               ChunkyPNG::Color.euclidean_distance_rgba(org_color, new_img[x, y])

--- a/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
@@ -268,7 +268,6 @@ module Capybara
 
             return color_matches if !@shift_distance_limit || @max_shift_distance == Float::INFINITY
 
-            # @type [Numeric]
             shift_distance = (color_matches && 0) ||
               shift_distance_at(new_img, old_img, x, y, color_distance_limit: @color_distance_limit)
             if shift_distance && (@max_shift_distance.nil? || shift_distance > @max_shift_distance)

--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -124,14 +124,14 @@ module Capybara
             image.resize(1.* new_width / new_height)
           end
 
-          def load_images(old_file_name, new_file_name, driver = self)
-            [driver.from_file(old_file_name), driver.from_file(new_file_name)]
+          def load_images(old_file_name, new_file_name)
+            [from_file(old_file_name), from_file(new_file_name)]
           end
 
           def from_file(filename)
             result = ::Vips::Image.new_from_file(filename)
 
-            result = result.colourspace("srgb") if result.bands < 3
+            result = result.colourspace(:srgb) if result.bands < 3
             result = result.bandjoin(255) if result.bands == 3
 
             result
@@ -157,11 +157,6 @@ module Capybara
           end
 
           class VipsUtil
-            def self.difference(old_image, new_image, color_distance: 0)
-              diff_mask = difference_mask(color_distance, new_image, old_image)
-              difference_region_by(diff_mask).to_edge_coordinates
-            end
-
             def self.difference_area(old_image, new_image, color_distance: 0)
               difference_mask = difference_mask(color_distance, new_image, old_image)
               difference_area_size_by(difference_mask)

--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -73,7 +73,7 @@ module Capybara
             #       so after we cropped files and stored in the same file, the next load will recover old version instead of cropped
             #       Workaround to make vips works with cropped versions
             Vips.cache_set_max(0)
-            Vips.vips_cache_set_max(1000)
+            Vips.cache_set_max(1000)
 
             result
           end
@@ -121,7 +121,7 @@ module Capybara
           end
 
           def resize_image_to(image, new_width, new_height)
-            image.resize(1.* new_width / new_height)
+            image.resize(new_width.to_f / new_height)
           end
 
           def load_images(old_file_name, new_file_name)

--- a/lib/capybara/screenshot/diff/image_compare.rb
+++ b/lib/capybara/screenshot/diff/image_compare.rb
@@ -85,8 +85,8 @@ module Capybara
             self.difference_region = Region.from_edge_coordinates(
               0,
               0,
-              [driver.width_for(old_image), driver.width_for(new_image)].min,
-              [driver.height_for(old_image), driver.height_for(new_image)].min
+              [driver.width_for(old_image), driver.width_for(new_image)].min || 0,
+              [driver.height_for(old_image), driver.height_for(new_image)].min || 0
             )
 
             return different(*images)
@@ -122,7 +122,7 @@ module Capybara
         end
 
         def old_file_exists?
-          @old_file_name && File.exist?(@old_file_name)
+          !!@old_file_name && File.exist?(@old_file_name)
         end
 
         def reset

--- a/lib/capybara/screenshot/diff/stabilization.rb
+++ b/lib/capybara/screenshot/diff/stabilization.rb
@@ -103,8 +103,8 @@ module Capybara
         def prepare_page_for_screenshot(timeout:)
           assert_images_loaded(timeout: timeout)
 
-          if Capybara::Screenshot.blur_active_element
-            blurred_input = blur_from_focused_element
+          blurred_input = if Capybara::Screenshot.blur_active_element
+            blur_from_focused_element
           end
 
           if Capybara::Screenshot.hide_caret

--- a/lib/capybara/screenshot/diff/test_methods.rb
+++ b/lib/capybara/screenshot/diff/test_methods.rb
@@ -29,25 +29,23 @@ module Capybara
           @test_screenshots = nil
         end
 
-        def group_parts
-          parts = []
-          parts << @screenshot_section if @screenshot_section.present?
-          parts << @screenshot_group if @screenshot_group.present?
-          parts
-        end
-
+        # @param [(Symbol | String)] name
+        # @return [String]
         def full_name(name)
-          File.join group_parts.push(name).map(&:to_s)
+          File.join *group_parts.push(name.to_s)
         end
 
+        # @return [String]
         def screenshot_dir
-          File.join [Screenshot.screenshot_area] + group_parts
+          File.join *([Screenshot.screenshot_area] + group_parts)
         end
 
+        # @param [(Symbol | String)] name
         def screenshot_section(name)
           @screenshot_section = name.to_s
         end
 
+        # @param [(Symbol | String)] name of the group
         def screenshot_group(name)
           @screenshot_group = name.to_s
           @screenshot_counter = 0
@@ -56,6 +54,9 @@ module Capybara
           FileUtils.rm_rf screenshot_dir
         end
 
+        # @param [(Symbol | String)] name
+        # @param [Integer] skip_stack_frames
+        # @param [**untyped] options
         # @return [Boolean] whether a screenshot was taken
         def screenshot(name, skip_stack_frames: 0, **options)
           return false unless Screenshot.active?
@@ -94,12 +95,19 @@ module Capybara
         end
 
         def assert_image_not_changed(caller, name, comparison)
-          return unless comparison.different?
+          return nil unless comparison.different?
 
           "Screenshot does not match for '#{name}' #{comparison.error_message}\nat #{caller}"
         end
 
         private
+
+        def group_parts
+          parts = []
+          parts << @screenshot_section if @screenshot_section.present?
+          parts << @screenshot_group if @screenshot_group.present?
+          parts
+        end
 
         def calculate_crop_region(driver_options)
           crop_coordinates = driver_options.delete(:crop)
@@ -137,7 +145,7 @@ module Capybara
 
           result = []
           result.concat(build_regions_for(bounds_for_css(*css_selectors))) unless css_selectors.empty?
-          result.concat(build_regions_for(regions.flatten&.each_slice(4))) unless regions.empty?
+          result.concat(build_regions_for(regions.flatten.each_slice(4))) unless regions.empty?
           result.compact!
 
           result.map! { |region| crop_region.find_relative_intersect(region) } if crop_region

--- a/lib/capybara/screenshot/diff/test_methods.rb
+++ b/lib/capybara/screenshot/diff/test_methods.rb
@@ -29,23 +29,18 @@ module Capybara
           @test_screenshots = nil
         end
 
-        # @param [(Symbol | String)] name
-        # @return [String]
         def full_name(name)
-          File.join *group_parts.push(name.to_s)
+          File.join(*group_parts.push(name.to_s))
         end
 
-        # @return [String]
         def screenshot_dir
-          File.join *([Screenshot.screenshot_area] + group_parts)
+          File.join(*([Screenshot.screenshot_area] + group_parts))
         end
 
-        # @param [(Symbol | String)] name
         def screenshot_section(name)
           @screenshot_section = name.to_s
         end
 
-        # @param [(Symbol | String)] name of the group
         def screenshot_group(name)
           @screenshot_group = name.to_s
           @screenshot_counter = 0
@@ -54,10 +49,6 @@ module Capybara
           FileUtils.rm_rf screenshot_dir
         end
 
-        # @param [(Symbol | String)] name
-        # @param [Integer] skip_stack_frames
-        # @param [**untyped] options
-        # @return [Boolean] whether a screenshot was taken
         def screenshot(name, skip_stack_frames: 0, **options)
           return false unless Screenshot.active?
           return false if window_size_is_wrong?
@@ -95,7 +86,7 @@ module Capybara
         end
 
         def assert_image_not_changed(caller, name, comparison)
-          return nil unless comparison.different?
+          return unless comparison.different?
 
           "Screenshot does not match for '#{name}' #{comparison.error_message}\nat #{caller}"
         end

--- a/sig/lib/capybara/screenshot/diff.rbs
+++ b/sig/lib/capybara/screenshot/diff.rbs
@@ -19,7 +19,7 @@ module Capybara
 
       ASSERTION: untyped
 
-      def self.default_options: () -> { area_size_limit: untyped, color_distance_limit: untyped, driver: untyped, shift_distance_limit: untyped, skip_area: untyped, stability_time_limit: untyped, tolerance: untyped, wait: untyped }
+      def self.default_options: () -> TestMethods::input_options
 
       def self.included: (untyped klass) -> untyped
 

--- a/sig/lib/capybara/screenshot/diff.rbs
+++ b/sig/lib/capybara/screenshot/diff.rbs
@@ -1,0 +1,33 @@
+module Capybara
+  module Screenshot
+    extend Os
+
+    def self.root=: (untyped path) -> untyped
+
+    def self.active?: () -> bool
+
+    def self.screenshot_area: () -> untyped
+
+    # @return [Pathname] absolute path to the screenshot start directory
+    def self.screenshot_area_abs: () -> untyped
+
+    # Module to track screen shot changes
+    module Diff
+      include Capybara::Screenshot::Os
+
+      AVAILABLE_DRIVERS: untyped
+
+      ASSERTION: untyped
+
+      def self.default_options: () -> { area_size_limit: untyped, color_distance_limit: untyped, driver: untyped, shift_distance_limit: untyped, skip_area: untyped, stability_time_limit: untyped, tolerance: untyped, wait: untyped }
+
+      def self.included: (untyped klass) -> untyped
+
+      private
+
+      EMPTY_LINE: "\n\n"
+
+      def track_failures: (Array[untyped] screenshots, (Array[String] | String) original_caller) -> void
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff.rbs
+++ b/sig/lib/capybara/screenshot/diff.rbs
@@ -8,7 +8,6 @@ module Capybara
 
     def self.screenshot_area: () -> untyped
 
-    # @return [Pathname] absolute path to the screenshot start directory
     def self.screenshot_area_abs: () -> untyped
 
     # Module to track screen shot changes

--- a/sig/lib/capybara/screenshot/diff/browser_helpers.rbs
+++ b/sig/lib/capybara/screenshot/diff/browser_helpers.rbs
@@ -1,0 +1,37 @@
+module Capybara
+  module Screenshot
+    module BrowserHelpers
+      def current_capybara_driver_class: () -> untyped
+
+      def selenium?: () -> bool
+
+      def window_size_is_wrong?: () -> bool
+
+      def rect_for: (String css_selector) -> untyped
+
+      def bounds_for_css: (*String css_selectors) -> untyped
+
+      IMAGE_WAIT_SCRIPT: String
+
+      def pending_image_to_load: () -> untyped
+
+      HIDE_CARET_SCRIPT: String
+
+      def hide_caret: () -> untyped
+
+      FIND_ACTIVE_ELEMENT_SCRIPT: String
+
+      def blur_from_focused_element: () -> untyped
+
+      GET_BOUNDING_CLIENT_RECT_SCRIPT: String
+
+      def all_visible_regions_for: (String selector) -> untyped
+
+      def region_for: (untyped element) -> untyped
+
+      private
+
+      def create_output_directory_for: (String file_name) -> untyped
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/browser_helpers.rbs
+++ b/sig/lib/capybara/screenshot/diff/browser_helpers.rbs
@@ -3,7 +3,7 @@ module Capybara
     module BrowserHelpers
       def current_capybara_driver_class: () -> untyped
 
-      def selenium?: () -> bool
+      def selenium?: () -> bool?
 
       def window_size_is_wrong?: () -> bool
 

--- a/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
@@ -5,11 +5,11 @@ module Capybara
         class BaseDriver[ImageEntity]
           type options_entity = {
               area_size_limit?: Integer?,
-              color_distance_limit?: Integer?,
-              driver: (:auto | :vips | :chunky_png),
-              shift_distance_limit?: Integer?,
-              skip_area?: Array[Region],
-              stability_time_limit?: Float?,
+              color_distance_limit?: Numeric?,
+              driver: (:auto | :vips | :chunky_png)?,
+              shift_distance_limit?: (Numeric | bool)?,
+              skip_area?: Array[Region]?,
+              stability_time_limit?: (Numeric | bool)?,
               tolerance?: Float?,
               wait?: Integer?
             }

--- a/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
@@ -4,14 +4,14 @@ module Capybara
       module Drivers
         class BaseDriver[ImageEntity]
           type options_entity = {
-              area_size_limit: Integer?,
-              color_distance_limit: Integer?,
-              driver: [:vips, :chunky_png],
-              shift_distance_limit: Integer?,
-              skip_area: Array[Region],
-              stability_time_limit: Float?,
-              tolerance: Float?,
-              wait: Integer?
+              area_size_limit?: Integer?,
+              color_distance_limit?: Integer?,
+              driver: (:auto | :vips | :chunky_png),
+              shift_distance_limit?: Integer?,
+              skip_area?: Array[Region],
+              stability_time_limit?: Float?,
+              tolerance?: Float?,
+              wait?: Integer?
             }
 
           type color = [Integer, Integer, Integer, Integer]

--- a/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
@@ -1,0 +1,67 @@
+module Capybara
+  module Screenshot
+    module Diff
+      module Drivers
+        class BaseDriver[ImageEntity]
+          type options_entity = ::Hash[Symbol, untyped]
+          type color = [Integer, Integer, Integer, Integer]
+
+          attr_reader new_file_name: String
+
+          attr_reader old_file_name: String
+
+          attr_reader options: options_entity
+
+          def initialize: (String new_file_name, ?untyped? old_file_name, ?options_entity options) -> void
+
+          def skip_area=: (Array[Region] new_skip_area) -> void
+
+          # Resets the calculated data about the comparison with regard to the "new_image".
+          # Data about the original image is kept.
+          def reset: () -> void
+
+          def shift_distance_equal?: () -> bool
+
+          def shift_distance_different?: () -> bool
+
+          def find_difference_region: (ImageEntity new_image, ImageEntity old_image, (Integer | Float) color_distance_limit, (Integer | Float) _shift_distance_limit, Integer _area_size_limit, ?fast_fail: bool) -> [(Region | nil), (ImageEntity | untyped | nil)]
+
+          def adds_error_details_to: (::Hash[Symbol, untyped] _log) -> void
+
+          def inscribed?: (untyped dimensions, ImageEntity i) -> bool
+
+          def crop: (Region region, ImageEntity i) -> ImageEntity
+
+          def filter_image_with_median: (ImageEntity image, untyped median_filter_window_size) -> ImageEntity
+
+          def add_black_box: (untyped memo, Region region) -> void
+
+          def chunky_png_comparator: () -> ImageCompare
+
+          def difference_level: (untyped diff_mask, ImageEntity old_img, ?Region? _region) -> Float
+
+          def image_area_size: (ImageEntity old_img) -> Integer
+
+          def height_for: (ImageEntity image) -> Integer
+
+          def width_for: (ImageEntity image) -> Integer
+
+          # Vips could not work with the same file. Per each process we require to create new file
+          def save_image_to: (ImageEntity image, String filename) -> void
+
+          def resize_image_to: (ImageEntity image, Integer new_width, Integer new_height) -> ImageEntity
+
+          def load_images: (String old_file_name, String new_file_name) -> [ImageEntity, ImageEntity]
+
+          def from_file: (String filename) -> ImageEntity
+
+          def dimension_changed?: (ImageEntity old_image, ImageEntity new_image) -> bool
+
+          def dimension: (ImageEntity image) -> ::Array[untyped]
+
+          def draw_rectangles: ([ImageEntity, ImageEntity] images, Region region, color rgba) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
@@ -3,7 +3,17 @@ module Capybara
     module Diff
       module Drivers
         class BaseDriver[ImageEntity]
-          type options_entity = ::Hash[Symbol, untyped]
+          type options_entity = {
+              area_size_limit: Integer?,
+              color_distance_limit: Integer?,
+              driver: [:vips, :chunky_png],
+              shift_distance_limit: Integer?,
+              skip_area: Array[Region],
+              stability_time_limit: Float?,
+              tolerance: Float?,
+              wait: Integer?
+            }
+
           type color = [Integer, Integer, Integer, Integer]
 
           attr_reader new_file_name: String
@@ -12,7 +22,7 @@ module Capybara
 
           attr_reader options: options_entity
 
-          def initialize: (String new_file_name, ?untyped? old_file_name, ?options_entity options) -> void
+          def initialize: (String new_file_name, ?String? old_file_name, ?options_entity options) -> void
 
           def skip_area=: (Array[Region] new_skip_area) -> void
 

--- a/sig/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rbs
@@ -1,10 +1,10 @@
 module ChunkyPNG
   class Canvas
-
   end
 
   class Image
     def self.from_blob: (String str) -> Image
+
     def self.from_file: (String filename) -> Image
   end
 end
@@ -16,27 +16,59 @@ module Capybara
         class ChunkyPNGDriver < BaseDriver[ChunkyPNG::Canvas]
           private
 
-          def build_region_for_whole_image: (untyped new_image) -> untyped
+          def build_region_for_whole_image: (ChunkyPNG::Image new_image) -> Region?
 
-          def find_diff_rectangle: (untyped org_img, untyped new_img, untyped area_coordinates) -> (Region? | nil)
+          def find_diff_rectangle: (
+              ChunkyPNG::Image org_img,
+              ChunkyPNG::Image new_img,
+              (Region | Region::raw_region_entity) area_coordinates
+            ) -> Region?
 
-          def find_top: (untyped old_img, untyped new_img) -> (::Array[untyped] | nil)
+          def find_top: (ChunkyPNG::Image old_img, ChunkyPNG::Image new_img) -> Region::raw_region_entity?
 
-          def find_left_right_and_top: (untyped old_img, untyped new_img, untyped region) -> ::Array[untyped]
+          def find_left_right_and_top: (
+              ChunkyPNG::Image old_img,
+              ChunkyPNG::Image new_img,
+              (Region | Region::raw_region_entity) region
+            ) -> Region::raw_region_entity
 
-          def find_bottom: (untyped old_img, untyped new_img, untyped left, untyped right, untyped bottom) -> untyped
+          def find_bottom: (
+              ChunkyPNG::Image old_img,
+              ChunkyPNG::Image new_img,
+              Integer left,
+              Integer right,
+              Integer bottom
+            ) -> Integer
 
-          def same_color?: (untyped old_img, untyped new_img, untyped x, untyped y) -> (true | untyped)
+          def same_color?: (ChunkyPNG::Image old_img, ChunkyPNG::Image new_img, Integer x, Integer y) -> bool
 
-          def skipped_region?: (untyped x, untyped y) -> (false | untyped)
+          def skipped_region?: (Integer x, Integer y) -> bool
 
-          def color_distance_at: (untyped new_img, untyped old_img, untyped x, untyped y, shift_distance_limit: untyped) -> untyped
+          def color_distance_at: (
+              ChunkyPNG::Image new_img,
+              ChunkyPNG::Image old_img,
+              Integer x,
+              Integer y,
+              shift_distance_limit: Numeric?
+            ) -> Float
 
-          def shift_distance_at: (untyped new_img, untyped old_img, untyped x, untyped y, color_distance_limit: untyped) -> untyped
+          def shift_distance_at: (
+              ChunkyPNG::Image new_img,
+              ChunkyPNG::Image old_img,
+              Integer x,
+              Integer y,
+              color_distance_limit: Numeric?
+            ) -> Numeric
 
-          def color_matches: (untyped new_img, untyped org_color, untyped x, untyped y, untyped color_distance_limit) -> untyped
+          def color_matches: (
+              ChunkyPNG::Image new_img,
+              Integer org_color,
+              Integer x,
+              Integer y,
+              Numeric? color_distance_limit
+            ) -> bool
 
-          def _load_images: (untyped old_file, untyped new_file) -> ::Array[untyped]
+          def _load_images: (String old_file, String new_file) -> [ChunkyPNG::Image, ChunkyPNG::Image]
         end
       end
     end

--- a/sig/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rbs
@@ -1,0 +1,44 @@
+module ChunkyPNG
+  class Canvas
+
+  end
+
+  class Image
+    def self.from_blob: (String str) -> Image
+    def self.from_file: (String filename) -> Image
+  end
+end
+
+module Capybara
+  module Screenshot
+    module Diff
+      module Drivers
+        class ChunkyPNGDriver < BaseDriver[ChunkyPNG::Canvas]
+          private
+
+          def build_region_for_whole_image: (untyped new_image) -> untyped
+
+          def find_diff_rectangle: (untyped org_img, untyped new_img, untyped area_coordinates) -> (Region? | nil)
+
+          def find_top: (untyped old_img, untyped new_img) -> (::Array[untyped] | nil)
+
+          def find_left_right_and_top: (untyped old_img, untyped new_img, untyped region) -> ::Array[untyped]
+
+          def find_bottom: (untyped old_img, untyped new_img, untyped left, untyped right, untyped bottom) -> untyped
+
+          def same_color?: (untyped old_img, untyped new_img, untyped x, untyped y) -> (true | untyped)
+
+          def skipped_region?: (untyped x, untyped y) -> (false | untyped)
+
+          def color_distance_at: (untyped new_img, untyped old_img, untyped x, untyped y, shift_distance_limit: untyped) -> untyped
+
+          def shift_distance_at: (untyped new_img, untyped old_img, untyped x, untyped y, color_distance_limit: untyped) -> untyped
+
+          def color_matches: (untyped new_img, untyped org_color, untyped x, untyped y, untyped color_distance_limit) -> untyped
+
+          def _load_images: (untyped old_file, untyped new_file) -> ::Array[untyped]
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/drivers/utils.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/utils.rbs
@@ -1,0 +1,11 @@
+module Capybara
+  module Screenshot
+    module Diff
+      module Utils
+        def self.detect_available_drivers: () -> Array[Symbol]
+
+        def self.detect_test_framework_assert: () -> (untyped | RuntimeError)
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/drivers/vips_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/vips_driver.rbs
@@ -1,0 +1,29 @@
+module ::Vips
+  class Image
+    def self.new_from_file: (String filename) -> Image
+  end
+end
+
+module Capybara
+  module Screenshot
+    module Diff
+      module Drivers
+        class VipsDriver < BaseDriver[Vips::Image]
+          PNG_EXTENSION: String
+
+          class VipsUtil
+            def self.difference: (Vips::Image old_image, Vips::Image new_image, ?color_distance: ::Integer) -> [Integer, Integer, Integer, Integer]
+
+            def self.difference_area: (Vips::Image old_image, Vips::Image new_image, ?color_distance: ::Integer) -> (Integer | Float)
+
+            def self.difference_area_size_by: (Vips::Image difference_mask) -> (Integer | Float)
+
+            def self.difference_mask: (Float color_distance, Vips::Image old_image, Vips::Image new_image) -> Vips::Image
+
+            def self.difference_region_by: (Vips::Image diff_mask) -> (nil | Region)
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/drivers/vips_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/vips_driver.rbs
@@ -18,7 +18,7 @@ module Capybara
 
             def self.difference_area_size_by: (Vips::Image difference_mask) -> (Integer | Float)
 
-            def self.difference_mask: (Float color_distance, Vips::Image old_image, Vips::Image new_image) -> Vips::Image
+            def self.difference_mask: (Numeric color_distance, Vips::Image old_image, Vips::Image new_image) -> Vips::Image
 
             def self.difference_region_by: (Vips::Image diff_mask) -> (nil | Region)
           end

--- a/sig/lib/capybara/screenshot/diff/image_compare.rbs
+++ b/sig/lib/capybara/screenshot/diff/image_compare.rbs
@@ -28,7 +28,7 @@ module Capybara
 
         attr_accessor color_distance_limit: untyped
 
-        def initialize: (String new_file_name, ?String? old_file_name, ?::Hash[Symbol, untyped] options) -> void
+        def initialize: (String new_file_name, ?(String | Drivers::BaseDriver::options_entity)? old_file_name, ?Drivers::BaseDriver::options_entity options) -> void
 
         def skip_area=: (Array[Region] new_skip_area) -> void
 
@@ -52,9 +52,9 @@ module Capybara
 
         def error_message: () -> String
 
-        def difference_coordinates: () -> Array[Integer]
+        def difference_coordinates: () -> Region::raw_region_entity
 
-        def difference_region_area_size: () -> Integer
+        def difference_region_area_size: () -> Numeric
 
         private
 

--- a/sig/lib/capybara/screenshot/diff/image_compare.rbs
+++ b/sig/lib/capybara/screenshot/diff/image_compare.rbs
@@ -1,0 +1,91 @@
+module Capybara
+  module Screenshot
+    module Diff
+      LOADED_DRIVERS: ::Hash[Symbol, untyped]
+
+      # Compare two images and determine if they are equal, different, or within some comparison
+      # range considering color values and difference area size.
+      class ImageCompare
+        TMP_FILE_SUFFIX: "~"
+
+        attr_reader driver: untyped
+
+        attr_reader driver_options: untyped
+
+        attr_reader annotated_new_file_name: String
+
+        attr_reader annotated_old_file_name: String
+
+        attr_reader new_file_name: String
+
+        attr_reader old_file_name: String
+
+        attr_reader skip_area: untyped
+
+        attr_accessor shift_distance_limit: untyped
+
+        attr_accessor area_size_limit: untyped
+
+        attr_accessor color_distance_limit: untyped
+
+        def initialize: (String new_file_name, ?String? old_file_name, ?::Hash[Symbol, untyped] options) -> void
+
+        def skip_area=: (Array[Region] new_skip_area) -> void
+
+        # Compare the two image files and return `true` or `false` as quickly as possible.
+        # Return falsely if the old file does not exist or the image dimensions do not match.
+        def quick_equal?: () -> bool
+
+        # Compare the two images referenced by this object, and return `true` if they are different,
+        # and `false` if they are the same.
+        def different?: () -> bool
+
+        def clean_tmp_files: () -> void
+
+        def save: (untyped old_img, untyped new_img, String annotated_old_file_name, String annotated_new_file_name) -> void
+
+        def old_file_exists?: () -> bool
+
+        def reset: () -> void
+
+        NEW_LINE: "\n"
+
+        def error_message: () -> String
+
+        def difference_coordinates: () -> Array[Integer]
+
+        def difference_region_area_size: () -> Integer
+
+        private
+
+        attr_accessor difference_region: untyped
+
+        def different: (untyped old_image, untyped new_image) -> true
+
+        def find_driver_class_for: (untyped driver) -> void
+
+        def preprocess_images: (Array[untyped] images, ?untyped driver) -> ::Array[untyped]
+
+        def preprocess_image: (untyped image, ?untyped driver) -> untyped
+
+        def old_file_size: () -> Integer
+
+        def new_file_size: () -> Integer
+
+        def not_different: () -> false
+
+        def difference_region_empty?: (untyped new_image, Region region) -> bool
+
+        def annotate_and_save: (untyped images, Region region) -> void
+
+        DIFF_COLOR: ::Array[255 | 0]
+
+        def annotate_difference: (untyped images, Region region) -> void
+
+        SKIP_COLOR: ::Array[255 | 192 | 0]
+
+        def annotate_skip_areas: (untyped annotated_images, Array[Region] skip_areas) -> void
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/os.rbs
+++ b/sig/lib/capybara/screenshot/diff/os.rbs
@@ -1,0 +1,13 @@
+module Capybara
+  module Screenshot
+    module Os
+      ON_WINDOWS: bool
+
+      ON_MAC: bool
+
+      ON_LINUX: bool
+
+      def os_name: () -> ("windows" | "macos" | "linux" | "unknown")
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/region.rbs
+++ b/sig/lib/capybara/screenshot/diff/region.rbs
@@ -1,0 +1,43 @@
+class Region
+  type raw_region_entity = [Integer, Integer, Integer, Integer]
+
+  attr_accessor x: Integer
+
+  attr_accessor y: Integer
+
+  attr_accessor width: Integer
+
+  attr_accessor height: Integer
+
+  def initialize: (Integer x, Integer y, Integer width, Integer height) -> void
+
+  def self.from_top_left_corner_coordinates: (Integer x, Integer y, Integer width, Integer height) -> (nil | Region)
+
+  def self.from_edge_coordinates: (Integer left, Integer `top`, Integer right, Integer bottom) -> (nil | Region)
+
+  def to_edge_coordinates: () -> ::Array[Integer]
+
+  def to_top_left_corner_coordinates: () -> ::Array[Integer]
+
+  def top: () -> Integer
+
+  def bottom: () -> Integer
+
+  def left: () -> Integer
+
+  def right: () -> Integer
+
+  def size: () -> Integer
+
+  def to_a: () -> ::Array[Integer]
+
+  def find_intersect_with: (Region region) -> (nil | Region)
+
+  def intersect?: (Region region) -> bool
+
+  def move_by: (Integer right_by, Integer down_by) -> Region
+
+  def find_relative_intersect: (Region region) -> (nil | Region)
+
+  def cover?: (Integer x, Integer y) -> bool
+end

--- a/sig/lib/capybara/screenshot/diff/region.rbs
+++ b/sig/lib/capybara/screenshot/diff/region.rbs
@@ -1,5 +1,5 @@
 class Region
-  type raw_region_entity = [Integer, Integer, Integer, Integer]
+  type raw_region_entity = [Numeric, Numeric, Numeric, Numeric]
 
   attr_accessor x: Integer
 
@@ -13,7 +13,7 @@ class Region
 
   def self.from_top_left_corner_coordinates: (Integer x, Integer y, Integer width, Integer height) -> (nil | Region)
 
-  def self.from_edge_coordinates: (Integer left, Integer `top`, Integer right, Integer bottom) -> (nil | Region)
+  def self.from_edge_coordinates: (Integer left, Integer `top`, Integer right, Integer bottom) -> Region?
 
   def to_edge_coordinates: () -> ::Array[Integer]
 

--- a/sig/lib/capybara/screenshot/diff/stabilization.rbs
+++ b/sig/lib/capybara/screenshot/diff/stabilization.rbs
@@ -1,0 +1,37 @@
+module Capybara
+  module Screenshot
+    module Diff
+      module Stabilization
+        include Os
+
+        def take_stable_screenshot: (ImageCompare comparison, stability_time_limit: Integer, wait: Integer, crop: Region) -> void
+
+        def notice_how_to_avoid_this: () -> void
+
+        private
+
+        def build_snapshot_version_file_name: (ImageCompare comparison, Integer iteration, Time screenshot_started_at, ImageCompare stabilization_comparison) -> ::String
+
+        def make_stabilization_comparison_from: (String new_file_name, String previous_file_name, Drivers::BaseDriver::options_entity driver_options) -> ImageCompare
+
+        def reduce_retina_image_size: (String file_name, (Drivers::VipsDriver | Drivers::ChunkyPNGDriver) driver) -> void
+
+        def stabilization_images: (String base_file) -> Array[String]
+
+        def clean_stabilization_images: (String base_file) -> void
+
+        def prepare_page_for_screenshot: (timeout: Integer) -> untyped
+
+        def take_right_size_screenshot: (ImageCompare comparison, crop: (Region | nil)) -> void
+
+        def check_max_wait_time: (ImageCompare comparison, Time screenshot_started_at, max_wait_time: Integer) -> void
+
+        def annotate_stabilization_images: (ImageCompare comparison) -> void
+
+        def max_wait_time: (Float shift_distance_limit, Integer wait) -> Integer
+
+        def assert_images_loaded: (timeout: Integer) -> void
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/stabilization.rbs
+++ b/sig/lib/capybara/screenshot/diff/stabilization.rbs
@@ -4,7 +4,7 @@ module Capybara
       module Stabilization
         include Os
 
-        def take_stable_screenshot: (ImageCompare comparison, stability_time_limit: Integer, wait: Integer, crop: Region) -> void
+        def take_stable_screenshot: (ImageCompare comparison, stability_time_limit: (Numeric | bool)?, wait: Integer?, crop: Region?) -> void
 
         def notice_how_to_avoid_this: () -> void
 

--- a/sig/lib/capybara/screenshot/diff/test_methods.rbs
+++ b/sig/lib/capybara/screenshot/diff/test_methods.rbs
@@ -11,7 +11,7 @@ module Capybara
 
         type name_entity = (Symbol | String)
 
-        def initialize: () -> void
+        def initialize: (*untyped) -> void
 
         def group_parts: () -> Array[String]
 
@@ -21,22 +21,34 @@ module Capybara
 
         def screenshot_section: (name_entity name) -> void
 
-        def screenshot_group: (name_entity name) -> void
+        def screenshot_group: (name_entity? name) -> void
 
         # @return [Boolean] whether a screenshot was taken
         def screenshot: (name_entity name, ?skip_stack_frames: ::Integer, **untyped options) -> bool
 
-        def assert_image_not_changed: (String caller, String name, ImageCompare comparison) -> ::String?
+        %a{rbs:test:skip} def assert_image_not_changed: (String caller, String name, ImageCompare comparison) -> ::String?
 
         private
 
-        def calculate_crop_region: (Drivers::BaseDriver::options_entity driver_options) -> (nil | Region)
+        type input_options = {
+            area_size_limit: Integer?,
+            color_distance_limit: Integer?,
+            driver: (:auto | :vips | :chunky_png),
+            shift_distance_limit: Integer?,
+            skip_area: nil | Array[[Integer, Integer, Integer, Integer] | String] | String | [Integer, Integer, Integer, Integer],
+            stability_time_limit: Float?,
+            tolerance: Float?,
+            wait: Integer?
+          }
+
+        def calculate_crop_region: (input_options driver_options) -> (nil | Region)
 
         def create_output_directory_for: (String file_name) -> void
 
         def take_comparison_screenshot: (ImageCompare comparison, Region? crop, Integer stability_time_limit, Integer wait) -> void
 
         type skip_area_entity = String | Region::raw_region_entity
+
         def calculate_skip_area: ((skip_area_entity | Array[skip_area_entity]) skip_area, (nil | Region::raw_region_entity) crop) -> Array[Region]
 
         def build_regions_for: ((Enumerable[Region::raw_region_entity]) coordinates) -> Array[(Region | nil)]

--- a/sig/lib/capybara/screenshot/diff/test_methods.rbs
+++ b/sig/lib/capybara/screenshot/diff/test_methods.rbs
@@ -1,0 +1,46 @@
+# Add the `screenshot` method to ActionDispatch::IntegrationTest
+module Capybara
+  module Screenshot
+    module Diff
+      module TestMethods
+        include Stabilization
+
+        include Vcs
+
+        include BrowserHelpers
+
+        type name_entity = (Symbol | String)
+
+        def initialize: () -> void
+
+        def group_parts: () -> Array[String]
+
+        def full_name: (name_entity name) -> String
+
+        def screenshot_dir: () -> String
+
+        def screenshot_section: (name_entity name) -> void
+
+        def screenshot_group: (name_entity name) -> void
+
+        # @return [Boolean] whether a screenshot was taken
+        def screenshot: (name_entity name, ?skip_stack_frames: ::Integer, **untyped options) -> bool
+
+        def assert_image_not_changed: (String caller, String name, ImageCompare comparison) -> ::String?
+
+        private
+
+        def calculate_crop_region: (Drivers::BaseDriver::options_entity driver_options) -> (nil | Region)
+
+        def create_output_directory_for: (String file_name) -> void
+
+        def take_comparison_screenshot: (ImageCompare comparison, Region? crop, Integer stability_time_limit, Integer wait) -> void
+
+        type skip_area_entity = String | Region::raw_region_entity
+        def calculate_skip_area: ((skip_area_entity | Array[skip_area_entity]) skip_area, (nil | Region::raw_region_entity) crop) -> Array[Region]
+
+        def build_regions_for: ((Enumerable[Region::raw_region_entity]) coordinates) -> Array[(Region | nil)]
+      end
+    end
+  end
+end

--- a/sig/lib/capybara/screenshot/diff/test_methods.rbs
+++ b/sig/lib/capybara/screenshot/diff/test_methods.rbs
@@ -33,23 +33,23 @@ module Capybara
         type input_options = {
             area_size_limit: Integer?,
             color_distance_limit: Integer?,
-            driver: (:auto | :vips | :chunky_png),
+            driver: (:auto | :vips | :chunky_png)?,
             shift_distance_limit: Integer?,
             skip_area: nil | Array[[Integer, Integer, Integer, Integer] | String] | String | [Integer, Integer, Integer, Integer],
-            stability_time_limit: Float?,
+            stability_time_limit: (Float | bool)?,
             tolerance: Float?,
             wait: Integer?
           }
 
-        def calculate_crop_region: (input_options driver_options) -> (nil | Region)
+        def calculate_crop_region: (input_options driver_options) -> Region?
 
         def create_output_directory_for: (String file_name) -> void
 
-        def take_comparison_screenshot: (ImageCompare comparison, Region? crop, Integer stability_time_limit, Integer wait) -> void
+        def take_comparison_screenshot: (ImageCompare comparison, Region? crop, Numeric? stability_time_limit, Numeric? wait) -> void
 
         type skip_area_entity = String | Region::raw_region_entity
 
-        def calculate_skip_area: ((skip_area_entity | Array[skip_area_entity]) skip_area, (nil | Region::raw_region_entity) crop) -> Array[Region]
+        def calculate_skip_area: ((skip_area_entity | Array[skip_area_entity]) skip_area, (nil | String | Region | Region::raw_region_entity) crop) -> Array[Region]
 
         def build_regions_for: ((Enumerable[Region::raw_region_entity]) coordinates) -> Array[(Region | nil)]
       end

--- a/sig/lib/capybara/screenshot/diff/test_methods.rbs
+++ b/sig/lib/capybara/screenshot/diff/test_methods.rbs
@@ -23,8 +23,7 @@ module Capybara
 
         def screenshot_group: (name_entity? name) -> void
 
-        # @return [Boolean] whether a screenshot was taken
-        def screenshot: (name_entity name, ?skip_stack_frames: ::Integer, **untyped options) -> bool
+:        def screenshot: (name_entity name, ?skip_stack_frames: ::Integer, **untyped options) -> bool
 
         %a{rbs:test:skip} def assert_image_not_changed: (String caller, String name, ImageCompare comparison) -> ::String?
 

--- a/sig/lib/capybara/screenshot/diff/vcs.rbs
+++ b/sig/lib/capybara/screenshot/diff/vcs.rbs
@@ -1,0 +1,13 @@
+module Capybara
+  module Screenshot
+    module Diff
+      module Vcs
+        SILENCE_ERRORS: String
+
+        def restore_git_revision: (String name, String target_file_name) -> void
+
+        def checkout_vcs: (String name, String old_file_name, String new_file_name) -> void
+      end
+    end
+  end
+end

--- a/test/capybara/screenshot/diff/drivers/vips_driver_test.rb
+++ b/test/capybara/screenshot/diff/drivers/vips_driver_test.rb
@@ -168,7 +168,7 @@ begin
               old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
               new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
 
-              left, top, right, bottom = VipsDriver::VipsUtil.difference(old_image, new_image)
+              left, top, right, bottom = difference(old_image, new_image)
 
               assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
             end
@@ -177,7 +177,7 @@ begin
               old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
               new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
 
-              left, top, right, bottom = VipsDriver::VipsUtil.difference(old_image, new_image)
+              left, top, right, bottom = difference(old_image, new_image)
 
               assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
             end
@@ -187,6 +187,13 @@ begin
               new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/d.png").bandjoin(255)
 
               assert_equal 8, VipsDriver::VipsUtil.difference_area(old_image, new_image, color_distance: 10)
+            end
+
+            private
+
+            def difference(old_image, new_image, color_distance: 0)
+              diff_mask = VipsDriver::VipsUtil.difference_mask(color_distance, new_image, old_image)
+              VipsDriver::VipsUtil.difference_region_by(diff_mask).to_edge_coordinates
             end
           end
         end

--- a/test/capybara/screenshot/diff/stabilization_test.rb
+++ b/test/capybara/screenshot/diff/stabilization_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Capybara
+  module Screenshot
+    module Diff
+      class StabilizationTest < ActionDispatch::IntegrationTest
+        include TestMethods
+        include TestHelper
+
+        test 'several iterations to take stable screenshot' do
+          comparison = ::Minitest::Mock.new
+          def comparison.old_file_name; 'old.png'; end
+          def comparison.new_file_name; '01_a.png'; end
+          def comparison.driver; :vips; end
+          def comparison.reset; end
+          def comparison.driver_options; Capybara::Screenshot::Diff.default_options; end
+          def comparison.shift_distance_limit; nil; end
+
+          comparison.expect(:quick_equal?, false)
+          comparison.expect(:quick_equal?, false)
+          comparison.expect(:quick_equal?, true)
+
+          take_stable_screenshot(comparison, stability_time_limit: 1, wait: 1, crop: nil)
+        end
+      end
+    end
+  end
+end

--- a/test/capybara/screenshot/diff/stabilization_test.rb
+++ b/test/capybara/screenshot/diff/stabilization_test.rb
@@ -10,7 +10,6 @@ module Capybara
         include TestHelper
 
         test 'several iterations to take stable screenshot' do
-          # @type [ImageCompare]
           comparison = ::Minitest::Mock.new
           def comparison.old_file_name; 'old.png'; end
           def comparison.new_file_name; '01_a.png'; end

--- a/test/capybara/screenshot/diff/stabilization_test.rb
+++ b/test/capybara/screenshot/diff/stabilization_test.rb
@@ -10,6 +10,7 @@ module Capybara
         include TestHelper
 
         test 'several iterations to take stable screenshot' do
+          # @type [ImageCompare]
           comparison = ::Minitest::Mock.new
           def comparison.old_file_name; 'old.png'; end
           def comparison.new_file_name; '01_a.png'; end

--- a/test/capybara/screenshot/diff/test_methods_test.rb
+++ b/test/capybara/screenshot/diff/test_methods_test.rb
@@ -35,7 +35,7 @@ module Capybara
         end
 
         def test_screenshot_support_drivers_options
-          skip unless defined?(Capybara::Screenshot::Diff::Drivers::VipsDriverTest)
+          skip 'vips is disabled' unless defined?(Capybara::Screenshot::Diff::Drivers::VipsDriverTest)
           screenshot("a", driver: :vips)
         end
 

--- a/test/capybara/screenshot/diff/test_methods_test.rb
+++ b/test/capybara/screenshot/diff/test_methods_test.rb
@@ -55,7 +55,7 @@ module Capybara
         end
 
         def test_skip_area_and_stability_time_limit
-          screenshot(:a, skip_area: [0, 0, 1, 1], stability_time_limit: true)
+          screenshot(:a, skip_area: [0, 0, 1, 1], stability_time_limit: 0.01)
         end
 
         private

--- a/test/support/setup_capybara_drivers.rb
+++ b/test/support/setup_capybara_drivers.rb
@@ -62,7 +62,7 @@ if ENV["CAPYBARA_DRIVER"] == "cuprite"
       app,
       browser_options: CHROME_ARGS,
       js_errors: true,
-      process_timeout: 20,
+      process_timeout: ENV["CI"] ? 40 : 20,
       screen_size: SCREEN_SIZE,
       timeout: ENV["CI"] ? 40 : 20,
       window_size: SCREEN_SIZE


### PR DESCRIPTION
Adds RBS files signatures to help IDE to find the problems or find usage of the unstructured scalars. RubyMine do not need any tools to start use them.

After run, found several problems and added hot-fixes:
* There are unused code, which should generate runtime error if it will be executed
* Made explicit boolean returns
* Explicit driver options types to prepare to move into named params

