### PR TITLE
skip_area with CSS selectors is not working

### DIFF
--- a/lib/capybara/screenshot/diff/image_compare.rb
+++ b/lib/capybara/screenshot/diff/image_compare.rb
@@ -23,15 +23,9 @@ module Capybara
           @annotated_old_file_name = "#{new_file_name.chomp(".png")}.committed.png"
           @annotated_new_file_name = "#{new_file_name.chomp(".png")}.latest.png"
 
-          @driver_options = options
+          @driver_options = options.dup
 
-          @color_distance_limit = options[:color_distance_limit] || 0
-          @area_size_limit = options[:area_size_limit]
-          @shift_distance_limit = options[:shift_distance_limit]
-          @dimensions = options[:dimensions]
-          @skip_area = options[:skip_area]
-          @tolerance = options[:tolerance]
-          @median_filter_window_size = options[:median_filter_window_size]
+          assign_attributes_with(@driver_options)
 
           driver_klass = find_driver_class_for(@driver_options.fetch(:driver, :chunky_png))
           @driver = driver_klass.new(@new_file_name, @old_file_name, **@driver_options)
@@ -159,6 +153,16 @@ module Capybara
         end
 
         private
+
+        def assign_attributes_with(options)
+          @color_distance_limit = options[:color_distance_limit] || 0
+          @area_size_limit = options[:area_size_limit]
+          @shift_distance_limit = options[:shift_distance_limit]
+          @dimensions = options[:dimensions].dup
+          @skip_area = options[:skip_area].dup
+          @tolerance = options[:tolerance]
+          @median_filter_window_size = options[:median_filter_window_size]
+        end
 
         attr_accessor :difference_region
 

--- a/lib/capybara/screenshot/diff/test_methods.rb
+++ b/lib/capybara/screenshot/diff/test_methods.rb
@@ -67,6 +67,12 @@ module Capybara
           wait = driver_options[:wait]
           crop = calculate_crop_region(driver_options)
 
+          # Allow nil or single or multiple areas
+          if driver_options[:skip_area]
+            # Cast skip area args to Region and makes relative to crop
+            driver_options[:skip_area] = calculate_skip_area(driver_options[:skip_area], crop)
+          end
+
           if @screenshot_counter
             name = "#{format("%02i", @screenshot_counter)}_#{name}"
             @screenshot_counter += 1
@@ -80,11 +86,6 @@ module Capybara
           checkout_vcs(name, comparison.old_file_name, comparison.new_file_name)
 
           return false unless comparison.old_file_exists?
-
-          # Allow nil or single or multiple areas
-          if driver_options[:skip_area]
-            comparison.skip_area = calculate_skip_area(driver_options[:skip_area], crop)
-          end
 
           take_comparison_screenshot(comparison, crop, stability_time_limit, wait)
 
@@ -129,6 +130,8 @@ module Capybara
           blurred_input&.click
         end
 
+        # Cast skip areas params into Region
+        # and if there is crop then makes absolute coordinates to eb relative to crop top left corner
         def calculate_skip_area(skip_area, crop)
           crop_region = crop && Region.new(*crop)
           skip_area = Array(skip_area)


### PR DESCRIPTION
I tried to run the repository's tests by cloning, doing `bundle install`, and `rake test:integration` but I get the following error:
https://gist.github.com/asavageiv/99e395bf46c950f114f7e2326fbab482

Is there an ENV I need to set?

In my own repository when using `skip_area` with a CSS selector I'm getting the following errors.

Using a string for `skip_area` leads to this error:
```
     Failure/Error: screenshot 'new-property', skip_area: '#property-short-code'
     
     NoMethodError:
       undefined method `reduce' for "#property-short-code":String
       Did you mean?  rescue
```

Using an array leads to this error:
```
     Failure/Error: screenshot 'new-property', skip_area: ['#property-short-code']
     
     NoMethodError:
       undefined method `to_top_left_corner_coordinates' for "#property-short-code":String
```

Related to [Allow to pass css selectors for skip_area and crop #47](https://github.com/donv/capybara-screenshot-diff/pull/47)