### PR TITLE
Draw skip areas only on the actual area and after the difference rectangle to not obscure non-skipped pixels.

### DIFF
--- a/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/chunky_png_driver.rb
@@ -168,13 +168,13 @@ module Capybara
             [old_file, new_file]
           end
 
-          def draw_rectangles(images, region, (r, g, b))
+          def draw_rectangles(images, region, (r, g, b), offset: 0)
             border_color = ChunkyPNG::Color.rgb(r, g, b)
             border_shadow = ChunkyPNG::Color.rgba(r, g, b, 100)
 
             images.map do |image|
               new_img = image.dup
-              new_img.rect(region.left - 1, region.top - 1, region.right + 1, region.bottom + 1, border_color)
+              new_img.rect(region.left - offset, region.top - offset, region.right + offset, region.bottom + offset, border_color)
               new_img.rect(region.left, region.top, region.right, region.bottom, border_shadow)
               new_img
             end

--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -137,9 +137,9 @@ module Capybara
             [width_for(image), height_for(image)]
           end
 
-          def draw_rectangles(images, region, rgba)
+          def draw_rectangles(images, region, rgba, offset: 0)
             images.map do |image|
-              image.draw_rect(rgba, region.left - 1, region.top - 1, region.width + 2, region.height + 2)
+              image.draw_rect(rgba, region.left - offset, region.top - offset, region.width + (offset * 2), region.height + (offset * 2))
             end
           end
 

--- a/lib/capybara/screenshot/diff/image_compare.rb
+++ b/lib/capybara/screenshot/diff/image_compare.rb
@@ -231,16 +231,16 @@ module Capybara
         end
 
         def annotate_and_save(images, region)
-          annotated_images = annotate_difference(images, region)
-          annotated_images = annotate_skip_areas(annotated_images, @skip_area) if @skip_area
+          images = annotate_skip_areas(images, @skip_area) if @skip_area
+          images = annotate_difference(images, region)
 
-          save(*annotated_images, @annotated_old_file_name, @annotated_new_file_name)
+          save(*images, @annotated_old_file_name, @annotated_new_file_name)
         end
 
         DIFF_COLOR = [255, 0, 0, 255].freeze
 
         def annotate_difference(images, region)
-          driver.draw_rectangles(images, region, DIFF_COLOR)
+          driver.draw_rectangles(images, region, DIFF_COLOR, offset: 1)
         end
 
         SKIP_COLOR = [255, 192, 0, 255].freeze

--- a/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
+++ b/sig/lib/capybara/screenshot/diff/drivers/base_driver.rbs
@@ -72,7 +72,7 @@ module Capybara
 
           def dimension: (ImageEntity image) -> dimension_entity
 
-          def draw_rectangles: (images_entity[ImageEntity] images, Region region, color rgba) -> void
+          def draw_rectangles: (images_entity[ImageEntity] images, Region region, color rgba, Integer offset) -> void
         end
       end
     end


### PR DESCRIPTION
Also not obscure the difference rectangle border.