### PR TITLE
Update readme with retina instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,18 @@ end
 ```
 
 
+**Note:** When using a retina device screenshots dimensions might be off. If
+you are using selenium with Rails system specs and/or (headless) chrome you can
+prevent this by setting the `force-device-scale-factor` argument to `1`. You
+can do so for example by using the following snippet:
+
+```ruby
+driven_by :selenium, using: :chrome_headless do |options|
+  options.args << '--force-device-scale-factor=1'
+end
+```
+
+
 ### Multiple Capybara drivers
 
 Often it is useful to test your app using different browsers.  To avoid the

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ test 'the cool' do
 end
 ```
 
-
 **Note:** When using a retina device screenshots dimensions might be off. If
 you are using selenium with Rails system specs and/or (headless) chrome you can
 prevent this by setting the `force-device-scale-factor` argument to `1`. You
@@ -223,7 +222,6 @@ driven_by :selenium, using: :chrome_headless do |options|
   options.args << '--force-device-scale-factor=1'
 end
 ```
-
 
 ### Multiple Capybara drivers
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,11 @@ end
 ```
 
 **Note:** When using a retina device screenshots dimensions might be off. If
-you are using selenium with Rails system specs and/or (headless) chrome you can
-prevent this by setting the `force-device-scale-factor` argument to `1`. You
-can do so for example by using the following snippet:
+you are using (headless) chrome you can prevent this by setting the
+`force-device-scale-factor` argument to `1`.
+
+For Rails system specs using selenium you can do so for example by using the
+following snippet:
 
 ```ruby
 driven_by :selenium, using: :chrome_headless do |options|


### PR DESCRIPTION
As per https://github.com/donv/capybara-screenshot-diff/issues/75 I have added a small section about configuring the chrome driver for producing consistent screenshot dimensions across retina and non-retina devices.