### PR TITLE
Fix "unix error: File name too long" when using Vips

### DIFF
--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -56,9 +56,14 @@ module Capybara
             VipsUtil.difference_area_size_by(diff_mask).to_f / image_area_size(old_img)
           end
 
+          MAX_FILENAME_LENGTH = 200
+
           # Vips could not work with the same file. Per each process we require to create new file
           def save_image_to(image, filename)
-            ::Dir::Tmpname.create([filename.to_s, PNG_EXTENSION]) do |tmp_image_filename|
+            # Dir::Tmpname will happily produce tempfile names that are too long for most unix filesystems,
+            # which leads to "unix error: File name too long". Apply a limit to avoid this.
+            limited_filename = filename.to_s[-MAX_FILENAME_LENGTH..] || filename.to_s
+            ::Dir::Tmpname.create([limited_filename, PNG_EXTENSION]) do |tmp_image_filename|
               image.write_to_file(tmp_image_filename)
               FileUtils.mv(tmp_image_filename, filename)
             end

--- a/test/capybara/screenshot/diff/image_compare_test.rb
+++ b/test/capybara/screenshot/diff/image_compare_test.rb
@@ -35,6 +35,16 @@ module Capybara
           assert_same_images("b-and-a.diff.png", comparison.annotated_image_path)
         end
 
+        test "it can handle very long input filenames" do
+          filename = %w(this-0000000000000000000000000000000000000000000000000-path/is/extremely/
+            long/and/if/the/directories/are/flattened/in/
+            the_temporary_they_will_cause_the_filename_to_exceed_
+            the_limit_on_most_unix_systems_which_nobody_wants.png).join
+          comparison = make_comparison(:a, :b, destination: (Rails.root / filename), driver: :vips)
+
+          assert comparison.different?
+        end
+
         test "it can be instantiated with vips adapter and tolerance option" do
           comp = make_comparison(:a, :b, driver: :vips, tolerance: 0.02)
           assert comp.quick_equal?


### PR DESCRIPTION
If a spec or test has a very long name or is nested deeply, the temporary path name formed by `Tmpname` (which preserves the directory names but removes the / separators) may exceed the 255 character filename limit present on many Linux filesystems.

This causes an exception like the one below when Vips tries to write the temporary file. Since

1) temporary file is ultimately moved to the target path, which doesn't exceed the length limit (since most of the length is in nested directory strcuture) and

2) `Tmpname` has some logic to avoid name collisions anyway

shortening the `prefix` passed to `Tmpname` to stay well below 255 characters resolves this error.

```
1) email preferences with EMAIL_PREFERENCES doc preferences #edit should not display any doc preference link for non-imaging backend users
     Failure/Error: raise Vips::Error

     Vips::Error:
       /tmp/homecircleciprojectspecscreenshotslinuxfeatures-email_notification_preferences_specemail_preferences_with_EMAIL_PREFERENCES_doc_preferences_edit_should_not_display_any_doc_preference_link_for_non-imaging_backend_users01_non_imaging_no_pref_link.committed.png20200101-2583-3jy9w5.png: unable to open for write
       unix error: File name too long
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/ruby-vips-2.1.4/lib/vips/operation.rb:228:in `build'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/ruby-vips-2.1.4/lib/vips/operation.rb:483:in `call'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/ruby-vips-2.1.4/lib/vips/image.rb:592:in `write_to_file'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/drivers/vips_driver.rb:112:in `block in save_image_to'
     # /usr/local/lib/ruby/3.1.0/tmpdir.rb:144:in `create'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/drivers/vips_driver.rb:111:in `save_image_to'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/image_compare.rb:138:in `save'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/image_compare.rb:134:in `annotate_and_save'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/image_compare.rb:114:in `different?'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff/test_methods.rb:115:in `assert_image_not_changed'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff.rb:99:in `block in track_failures'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff.rb:98:in `map'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff.rb:98:in `track_failures'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.6.3/lib/capybara/screenshot/diff.rb:87:in `block in included'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:457:in `instance_exec'
     # /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:457:in `instance_exec'
```