### PR TITLE
Verify that tests run after checkout.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Test that new contributors can run the tests directly after checkout.
+  test-minimal-setup:
+    name: Test with minimal setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+          bundler-cache: true
+      - name: Cache Webdrivers
+        uses: actions/cache@v3
+        with:
+          path: ~/.webdrivers
+          key: ${{ runner.os }}-webdrivers
+      - run: bin/rake test
+
   test:
     name: Functional Testing
     runs-on: ubuntu-latest # In order to install libvips 8.9+ version
@@ -113,7 +131,7 @@ jobs:
       github.event.pull_request.requested_reviewers.length > 0
     needs: [ test ]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 8
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
@@ -170,7 +188,11 @@ jobs:
           key: ${{ runner.os }}-webdrivers
 
       - name: Run tests
-        run: bin/rake test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 2
+          command: bin/rake test
 
   matrix-screenshot-driver:
     name: Test Integration Capybara & Image Drivers

--- a/lib/capybara/screenshot/diff/drivers/utils.rb
+++ b/lib/capybara/screenshot/diff/drivers/utils.rb
@@ -10,13 +10,13 @@ module Capybara
             result << :vips if defined?(Vips) || require("vips")
           rescue LoadError
             # vips not present
-            Object.send :remove_const, :Vips
+            Object.send(:remove_const, :Vips) if defined?(Vips)
           end
           begin
             result << :chunky_png if defined?(ChunkyPNG) || require("chunky_png")
           rescue LoadError
             # chunky_png not present
-            Object.send :remove_const, :ChunkyPNG
+            Object.send(:remove_const, :ChunkyPNG) if defined?(ChunkyPNG)
           end
           result
         end

--- a/lib/capybara/screenshot/diff/drivers/utils.rb
+++ b/lib/capybara/screenshot/diff/drivers/utils.rb
@@ -10,11 +10,13 @@ module Capybara
             result << :vips if defined?(Vips) || require("vips")
           rescue LoadError
             # vips not present
+            Object.send :remove_const, :Vips
           end
           begin
             result << :chunky_png if defined?(ChunkyPNG) || require("chunky_png")
           rescue LoadError
             # chunky_png not present
+            Object.send :remove_const, :ChunkyPNG
           end
           result
         end

--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -3,7 +3,7 @@
 begin
   require "vips"
 rescue LoadError => e
-  warn 'Required ruby-vips gem is missing. Add `gem "ruby-vips"` to Gemfile' if e.message.include?("vips")
+  raise 'Required ruby-vips gem is missing. Add `gem "ruby-vips"` to Gemfile' if e.message.match?(/vips/i)
   raise
 end
 

--- a/test/capybara/screenshot/diff/drivers/utils_test.rb
+++ b/test/capybara/screenshot/diff/drivers/utils_test.rb
@@ -9,6 +9,7 @@ module Capybara
     module Diff
       class UtilsTest < ActiveSupport::TestCase
         test "detect_available_drivers add vips when ruby-vips is available" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           Object.stub :require, ->(gem) { gem == "vips" } do
             assert_includes Utils.detect_available_drivers, :vips
           end

--- a/test/capybara/screenshot/diff/drivers/vips_driver_test.rb
+++ b/test/capybara/screenshot/diff/drivers/vips_driver_test.rb
@@ -2,213 +2,213 @@
 
 require "test_helper"
 
-begin
-  require "capybara/screenshot/diff/drivers/vips_driver"
+unless defined?(Vips)
+  warn "VIPS not present. Skipping VIPS driver tests."
+  return
+end
+require "capybara/screenshot/diff/drivers/vips_driver"
 
-  module Capybara
-    module Screenshot
-      module Diff
-        module Drivers
-          class VipsDriverTest < ActionDispatch::IntegrationTest
-            include TestMethodsStub
+module Capybara
+  module Screenshot
+    module Diff
+      module Drivers
+        class VipsDriverTest < ActionDispatch::IntegrationTest
+          include TestMethodsStub
 
-            setup do
-              @new_screenshot_result = Tempfile.new(%w[screenshot .png], Rails.root)
-            end
-
-            teardown do
-              if @new_screenshot_result
-                @new_screenshot_result.close
-                @new_screenshot_result.unlink
-              end
-
-              Vips.cache_set_max(0)
-              Vips.cache_set_max(1000)
-            end
-
-            test "#different? for equal is negative" do
-              comp = make_comparison(:a, :a)
-              assert_not comp.different?
-            end
-
-            test "#quick_equal? for equal is positive" do
-              comp = make_comparison(:a, :a)
-
-              assert comp.quick_equal?
-            end
-
-            test "it can be instantiated" do
-              assert VipsDriver.new
-            end
-
-            test "when different does not clean runtime files" do
-              comp = make_comparison(:a, :c)
-              assert comp.different?
-              assert_includes comp.error_message, "[11.0,3.0,49.0,21.0]"
-              assert File.exist?(comp.old_file_name)
-              assert File.exist?(comp.annotated_base_image_path)
-              assert File.exist?(comp.annotated_image_path)
-            end
-
-            test "when equal clean runtime files" do
-              comp = make_comparison(:c, :c)
-              assert_not comp.different?
-              assert_not File.exist?(comp.annotated_base_image_path)
-              assert_not File.exist?(comp.annotated_image_path)
-            end
-
-            test "compare of 1 pixel wide diff" do
-              comp = make_comparison(:a, :d)
-              assert comp.different?
-              assert_includes comp.error_message, "[9.0,6.0,10.0,14.0]"
-            end
-
-            test "compare with color_distance_limit above difference" do
-              comp = make_comparison(:a, :b, color_distance_limit: 255)
-              assert_not comp.different?
-            end
-
-            test "compare with color_distance_limit below difference" do
-              comp = make_comparison(:a, :b, color_distance_limit: 3)
-              assert comp.different?
-            end
-
-            test "compare with tolerance level more then area of the difference" do
-              comp = make_comparison(:a, :b, tolerance: 0.01)
-              assert comp.quick_equal?
-              assert_not comp.different?
-              assert_not comp.error_message
-            end
-
-            test "compare with tolerance level less then area of the difference" do
-              comp = make_comparison(:a, :b, tolerance: 0.000001)
-              assert_not comp.quick_equal?
-              assert comp.different?
-            end
-
-            test "compare with median_filter_window_size when images have 1px line difference" do
-              comp = make_comparison(:a, :d, median_filter_window_size: 3, color_distance_limit: 8)
-              assert comp.quick_equal?
-              assert_not comp.different?
-            end
-
-            test "quick_equal" do
-              comp = make_comparison(:a, :b)
-              assert_not comp.quick_equal?
-            end
-
-            test "quick_equal with color distance limit below current level" do
-              comp = make_comparison(:a, :b, color_distance_limit: 2)
-              assert_not comp.quick_equal?
-            end
-
-            test "quick_equal with color distance limit above current level" do
-              comp = make_comparison(:a, :b, color_distance_limit: 200)
-              assert comp.quick_equal?
-            end
-
-            test "size a vs a_cropped" do
-              comp = make_comparison(:a, :a_cropped)
-              assert comp.different?
-              assert_includes comp.error_message, "Screenshot dimension has been changed for "
-              assert_includes comp.error_message, "80x60"
-            end
-
-            test "quick_equal compare skips difference if skip_area covers it" do
-              comp = make_comparison(
-                :a,
-                :d,
-                skip_area: [
-                  Region.from_edge_coordinates(9, 0, 11, 80),
-                  Region.from_edge_coordinates(79, 79, 80, 80)
-                ]
-              )
-              assert comp.quick_equal?
-              assert_not comp.different?
-            end
-
-            test "quick_equal compare skips difference if skip_area does not cover it" do
-              comp = make_comparison(
-                :a,
-                :d,
-                skip_area: [
-                  Region.from_edge_coordinates(79, 79, 80, 80),
-                  Region.from_edge_coordinates(78, 78, 80, 80)
-                ]
-              )
-              assert_not comp.quick_equal?
-              assert comp.different?
-            end
-
-            # Test Interface Contracts
-
-            test "from_file loads image from path" do
-              driver = VipsDriver.new
-              assert driver.from_file(TEST_IMAGES_DIR / "a.png")
-            end
-
-            private
-
-            def make_comparison(old_img, new_img, options = {})
-              destination = Pathname.new(@new_screenshot_result.path)
-              super(old_img, new_img, destination: destination, **options.merge(driver: :vips))
-            end
-
-            def sample_region
-              [0, 0, 0, 0]
-            end
+          setup do
+            @new_screenshot_result = Tempfile.new(%w[screenshot .png], Rails.root)
           end
 
-          class VipsUtilTest < ActiveSupport::TestCase
-            test "segment difference without min color difference" do
-              old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
-              new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
-
-              left, top, right, bottom = difference(old_image, new_image)
-
-              assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
-
-              left, top, right, bottom = difference(old_image, new_image, color_distance: 0)
-
-              assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
+          teardown do
+            if @new_screenshot_result
+              @new_screenshot_result.close
+              @new_screenshot_result.unlink
             end
 
-            test "segment difference with min color difference" do
-              old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
-              new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
+            Vips.cache_set_max(0)
+            Vips.cache_set_max(1000)
+          end
 
-              left, top, right, bottom = difference(old_image, new_image, color_distance: 150)
+          test "#different? for equal is negative" do
+            comp = make_comparison(:a, :a)
+            assert_not comp.different?
+          end
 
-              assert_equal [26.0, 18.0, 27.0, 19.0], [left, top, right, bottom]
-            end
+          test "#quick_equal? for equal is positive" do
+            comp = make_comparison(:a, :a)
 
-            test "segment difference" do
-              old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
-              new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
+            assert comp.quick_equal?
+          end
 
-              left, top, right, bottom = difference(old_image, new_image)
+          test "it can be instantiated" do
+            assert VipsDriver.new
+          end
 
-              assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
-            end
+          test "when different does not clean runtime files" do
+            comp = make_comparison(:a, :c)
+            assert comp.different?
+            assert_includes comp.error_message, "[11.0,3.0,49.0,21.0]"
+            assert File.exist?(comp.old_file_name)
+            assert File.exist?(comp.annotated_base_image_path)
+            assert File.exist?(comp.annotated_image_path)
+          end
 
-            test "area of the difference" do
-              old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
-              new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/d.png").bandjoin(255)
+          test "when equal clean runtime files" do
+            comp = make_comparison(:c, :c)
+            assert_not comp.different?
+            assert_not File.exist?(comp.annotated_base_image_path)
+            assert_not File.exist?(comp.annotated_image_path)
+          end
 
-              assert_equal 8, VipsDriver::VipsUtil.difference_area(old_image, new_image, color_distance: 10)
-            end
+          test "compare of 1 pixel wide diff" do
+            comp = make_comparison(:a, :d)
+            assert comp.different?
+            assert_includes comp.error_message, "[9.0,6.0,10.0,14.0]"
+          end
 
-            private
+          test "compare with color_distance_limit above difference" do
+            comp = make_comparison(:a, :b, color_distance_limit: 255)
+            assert_not comp.different?
+          end
 
-            def difference(old_image, new_image, color_distance: nil)
-              diff_mask = VipsDriver::VipsUtil.difference_mask(new_image, old_image, color_distance)
-              VipsDriver::VipsUtil.difference_region_by(diff_mask).to_edge_coordinates
-            end
+          test "compare with color_distance_limit below difference" do
+            comp = make_comparison(:a, :b, color_distance_limit: 3)
+            assert comp.different?
+          end
+
+          test "compare with tolerance level more then area of the difference" do
+            comp = make_comparison(:a, :b, tolerance: 0.01)
+            assert comp.quick_equal?
+            assert_not comp.different?
+            assert_not comp.error_message
+          end
+
+          test "compare with tolerance level less then area of the difference" do
+            comp = make_comparison(:a, :b, tolerance: 0.000001)
+            assert_not comp.quick_equal?
+            assert comp.different?
+          end
+
+          test "compare with median_filter_window_size when images have 1px line difference" do
+            comp = make_comparison(:a, :d, median_filter_window_size: 3, color_distance_limit: 8)
+            assert comp.quick_equal?
+            assert_not comp.different?
+          end
+
+          test "quick_equal" do
+            comp = make_comparison(:a, :b)
+            assert_not comp.quick_equal?
+          end
+
+          test "quick_equal with color distance limit below current level" do
+            comp = make_comparison(:a, :b, color_distance_limit: 2)
+            assert_not comp.quick_equal?
+          end
+
+          test "quick_equal with color distance limit above current level" do
+            comp = make_comparison(:a, :b, color_distance_limit: 200)
+            assert comp.quick_equal?
+          end
+
+          test "size a vs a_cropped" do
+            comp = make_comparison(:a, :a_cropped)
+            assert comp.different?
+            assert_includes comp.error_message, "Screenshot dimension has been changed for "
+            assert_includes comp.error_message, "80x60"
+          end
+
+          test "quick_equal compare skips difference if skip_area covers it" do
+            comp = make_comparison(
+              :a,
+              :d,
+              skip_area: [
+                Region.from_edge_coordinates(9, 0, 11, 80),
+                Region.from_edge_coordinates(79, 79, 80, 80)
+              ]
+            )
+            assert comp.quick_equal?
+            assert_not comp.different?
+          end
+
+          test "quick_equal compare skips difference if skip_area does not cover it" do
+            comp = make_comparison(
+              :a,
+              :d,
+              skip_area: [
+                Region.from_edge_coordinates(79, 79, 80, 80),
+                Region.from_edge_coordinates(78, 78, 80, 80)
+              ]
+            )
+            assert_not comp.quick_equal?
+            assert comp.different?
+          end
+
+          # Test Interface Contracts
+
+          test "from_file loads image from path" do
+            driver = VipsDriver.new
+            assert driver.from_file(TEST_IMAGES_DIR / "a.png")
+          end
+
+          private
+
+          def make_comparison(old_img, new_img, options = {})
+            destination = Pathname.new(@new_screenshot_result.path)
+            super(old_img, new_img, destination: destination, **options.merge(driver: :vips))
+          end
+
+          def sample_region
+            [0, 0, 0, 0]
+          end
+        end
+
+        class VipsUtilTest < ActiveSupport::TestCase
+          test "segment difference without min color difference" do
+            old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
+            new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
+
+            left, top, right, bottom = difference(old_image, new_image)
+
+            assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
+
+            left, top, right, bottom = difference(old_image, new_image, color_distance: 0)
+
+            assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
+          end
+
+          test "segment difference with min color difference" do
+            old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
+            new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
+
+            left, top, right, bottom = difference(old_image, new_image, color_distance: 150)
+
+            assert_equal [26.0, 18.0, 27.0, 19.0], [left, top, right, bottom]
+          end
+
+          test "segment difference" do
+            old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
+            new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
+
+            left, top, right, bottom = difference(old_image, new_image)
+
+            assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
+          end
+
+          test "area of the difference" do
+            old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
+            new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/d.png").bandjoin(255)
+
+            assert_equal 8, VipsDriver::VipsUtil.difference_area(old_image, new_image, color_distance: 10)
+          end
+
+          private
+
+          def difference(old_image, new_image, color_distance: nil)
+            diff_mask = VipsDriver::VipsUtil.difference_mask(new_image, old_image, color_distance)
+            VipsDriver::VipsUtil.difference_region_by(diff_mask).to_edge_coordinates
           end
         end
       end
     end
   end
-rescue LoadError
-  warn "VIPS not present. Skipping VIPS driver tests."
 end

--- a/test/capybara/screenshot/diff/image_compare_test.rb
+++ b/test/capybara/screenshot/diff/image_compare_test.rb
@@ -3,7 +3,11 @@
 require "test_helper"
 require "minitest/stub_const"
 require "capybara/screenshot/diff/drivers/chunky_png_driver"
-require "capybara/screenshot/diff/drivers/vips_driver"
+if defined?(Vips)
+  require "capybara/screenshot/diff/drivers/vips_driver"
+elsif ENV['SCREENSHOT_DRIVER'] == 'vips'
+  raise 'Required `ruby-vips` gem or `vips` library is missing. Ensure "ruby-vips" gem and "vips" library is installed.'
+end
 
 module Capybara
   module Screenshot
@@ -22,11 +26,13 @@ module Capybara
         end
 
         test "it can be instantiated with vips adapter" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           comparison = ImageCompare.new("images/b.png", "images/b.base.png", driver: :vips)
           assert_kind_of Drivers::VipsDriver, comparison.driver
         end
 
         test "it generates annotation files on difference" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           comparison = make_comparison(:a, :b, driver: :vips)
 
           assert comparison.different?
@@ -36,6 +42,7 @@ module Capybara
         end
 
         test "it can handle very long input filenames" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           filename = %w(this-0000000000000000000000000000000000000000000000000-path/is/extremely/
             long/and/if/the/directories/are/flattened/in/
             the_temporary_they_will_cause_the_filename_to_exceed_
@@ -46,6 +53,7 @@ module Capybara
         end
 
         test "it can be instantiated with vips adapter and tolerance option" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           comp = make_comparison(:a, :b, driver: :vips, tolerance: 0.02)
           assert comp.quick_equal?
           assert_not comp.different?
@@ -60,6 +68,7 @@ module Capybara
         end
 
         test "for driver: :auto returns first from available drivers" do
+          skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
           comparison = ImageCompare.new("images/b.png", "images/b.base.png", driver: :auto)
           assert_kind_of Drivers::VipsDriver, comparison.driver
         end

--- a/test/integration/test_methods_system_test.rb
+++ b/test/integration/test_methods_system_test.rb
@@ -5,8 +5,8 @@ require "system_test_case"
 # NOTE: For this test we need only chrome browser,
 #       because we can spot problem by counting running chrome driver processes
 require "action_pack/version"
-unless [ActionPack::VERSION::MAJOR, ActionPack::VERSION::MINOR].join >= "60" && ENV["CAPYBARA_DRIVER"].include?("selenium_chrome")
-  warn "Regression only for 6x Rails and driven_by construction"
+unless ENV["CAPYBARA_DRIVER"].include?("selenium_chrome")
+  warn "Regression only for `driven_by :selenium_chrome` construction."
   return
 end
 


### PR DESCRIPTION
Allow running tests without VIPS installed.
Retry test once since JRuby runs sometimes time out.

The purpose is to allow new contributors to just check out the project and run the tests.