### PR TITLE
Use ceil before converting to an integer in BrowserHelpers.region_for

### DIFF
--- a/lib/capybara/screenshot/diff/browser_helpers.rb
+++ b/lib/capybara/screenshot/diff/browser_helpers.rb
@@ -83,7 +83,7 @@ module Capybara
       end
 
       def self.region_for(element)
-        element.evaluate_script(GET_BOUNDING_CLIENT_RECT_SCRIPT).map { |point| point.negative? ? 0 : point.to_i }
+        element.evaluate_script(GET_BOUNDING_CLIENT_RECT_SCRIPT).map { |point| point.negative? ? 0 : point.ceil.to_i }
       end
 
       def self.session


### PR DESCRIPTION
This prevents creating a region that is one pixel too small due to rounding down.

Fixes #87 