### PR TITLE
Move screenshot clearing to be before error raise

### DIFF
--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -80,8 +80,11 @@ module Capybara
 
         klass.teardown do
           if Screenshot.active? && @test_screenshots.present?
-            track_failures(@test_screenshots)
-            @test_screenshots.clear
+            begin
+              track_failures(@test_screenshots)
+            ensure
+              @test_screenshots.clear
+            end
           end
         end
       end

--- a/test/capybara/screenshot/diff_test.rb
+++ b/test/capybara/screenshot/diff_test.rb
@@ -127,6 +127,7 @@ module Capybara
 
           @test_screenshots = []
           @test_screenshots << ["my_test.rb:42", "sample_screenshot", mock]
+          mock.expect(:clear_screenshots, @test_screenshots)
         end
       end
 
@@ -174,6 +175,7 @@ module Capybara
           expected_message =
             "Screenshot does not match for 'sample_screenshot' expected error message for non minitest"
           assert_raises(RuntimeError, expected_message) { test_case.teardown }
+          assert(test_case.instance_variable_get(:@test_screenshots).empty?)
         end
       end
     end


### PR DESCRIPTION
When a spec or test would fail from a difference, the following specs/tests would fail with a generic “no base image” error with the stacktrace containing an error stating that the previous test base screenshot was not present:

```
First test failure: 

Minitest::Assertion:
  Screenshot does not match for 'features-email_notification_preferences_spec/email_preferences_with__review_requests_should_allow_rescan_customers_to_view_rescan_preference/00_rescan_preference_page_visited' ({"area_size":263590.0,"region":[256.0,19.0,1482.0,234.0],"difference_level":0.006523589743589743})
  /home/circleci/project/spec/screenshots/linux/features-email_notification_preferences_spec/email_preferences_with__review_requests_should_allow_rescan_customers_to_view_rescan_preference/00_rescan_preference_page_visited.png
  /home/circleci/project/spec/screenshots/linux/features-email_notification_preferences_spec/email_preferences_with__review_requests_should_allow_rescan_customers_to_view_rescan_preference/00_rescan_preference_page_visited.base.diff.png
  /home/circleci/project/spec/screenshots/linux/features-email_notification_preferences_spec/email_preferences_with__review_requests_should_allow_rescan_customers_to_view_rescan_preference/00_rescan_preference_page_visited.diff.png
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.12.0/lib/rspec/core/example.rb:457:in `instance_exec'......

Second test failure:
Failure/Error: raise "There is no original (base) screenshot version to compare, located: #{@base_image_path}" unless @base_image_path.exist?

RuntimeError:
  There is no original (base) screenshot version to compare, located: /home/circleci/project/spec/screenshots/linux/features-email_notification_preferences_spec/email_preferences_with__review_requests_should_allow_rescan_customers_to_view_rescan_preference/00_rescan_preference_page_visited.base.png
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff/image_compare.rb:106:in `_different?'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff/image_compare.rb:67:in `different?'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff/test_methods.rb:92:in `assert_image_not_changed'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff.rb:95:in `block in track_failures'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff.rb:94:in `map'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff.rb:94:in `track_failures'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/capybara-screenshot-diff-1.8.0/lib/capybara/screenshot/diff.rb:83:in `block in included'....
```

This bug was caused by the fact that in `diff.rb` the tested screenshots are cleared out after `track_failures`. This is a problem because `track_failures` raises an error if the screenshots are different; causing the code to break and not return to the clearing of the testing screenshots. In this PR, I have moved the clearing of the testing screenshots to happen inside of `track_failures` after the errors have been collected from the test screenshots.
