### PR TITLE
Added option `fail_on_difference`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,17 @@ Using an environment variable
 Capybara::Screenshot::Diff.enabled = ENV['COMPARE_SCREENSHOTS']
 ```
 
+### Tolerate screenshot differences
+
+To allow screenshot differences, but still fail on functional errors, you can set the followin option:
+
+```ruby
+Capybara::Screenshot::Diff.fail_on_difference = false
+```
+
+It defaults to `true`.  This can be useful in continuous integration to a generate a screenshot difference
+report while still reporting functional errors.
+
 ### Screen shot save path
 
 By default, `Capybara::Screenshot::Diff` saves screenshots to a

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -51,6 +51,7 @@ module Capybara
       mattr_accessor(:delayed) { true }
       mattr_accessor :area_size_limit
       mattr_accessor(:fail_if_new) { false }
+      mattr_accessor(:fail_on_difference) { true }
       mattr_accessor :color_distance_limit
       mattr_accessor(:enabled) { true }
       mattr_accessor :shift_distance_limit
@@ -109,10 +110,12 @@ module Capybara
           error = ASSERTION.new(test_screenshot_errors.join(EMPTY_LINE))
           error.set_backtrace([])
 
-          if is_a?(::Minitest::Runnable)
-            failures << error
-          else
-            raise error
+          if Capybara::Screenshot::Diff.fail_on_difference
+            if is_a?(::Minitest::Runnable)
+              failures << error
+            else
+              raise error
+            end
           end
         end
       end

--- a/test/capybara/screenshot/diff_test.rb
+++ b/test/capybara/screenshot/diff_test.rb
@@ -62,6 +62,16 @@ module Capybara
         screenshot "a"
       end
 
+      test "succeed on screenshot diff when fail_on_difference is false" do
+        Capybara::Screenshot::Diff.stub(:enabled, true) do
+          Capybara::Screenshot::Diff.stub(:fail_on_difference, false) do
+            test_case = SampleMiniTestCase.new(:_test_sample_screenshot_error)
+            test_case.run
+            assert_equal 0, test_case.failures.size
+          end
+        end
+      end
+
       def test_screenshot_with_alternate_save_path
         default_path = Capybara::Screenshot.save_path
         Capybara::Screenshot.save_path = "foo/bar"


### PR DESCRIPTION
We are currently generating screenshots on a separate branch in CI on one of our projects, and it will be useful to have this job be green when functional tests pass, while still generating the full screenshot difference report.