### PR TITLE
`ArgumentError: comparison of Float with nil failed` in `Screenshoter#wait_images_loaded`

### DIFF
--- a/lib/capybara/screenshot/diff/screenshoter.rb
+++ b/lib/capybara/screenshot/diff/screenshoter.rb
@@ -97,7 +97,7 @@ module Capybara
       end
 
       def prepare_page_for_screenshot(timeout:)
-        wait_images_loaded(timeout: timeout)
+        wait_images_loaded(timeout: timeout) if timeout
 
         blurred_input = if Screenshot.blur_active_element
           BrowserHelpers.blur_from_focused_element
@@ -111,13 +111,15 @@ module Capybara
       end
 
       def wait_images_loaded(timeout:)
+        return unless timeout
+
         start = Time.now
         loop do
           pending_image = BrowserHelpers.pending_image_to_load
           break unless pending_image
 
           if (Time.now - start) >= timeout
-            raise Capybara::Screenshot::Diff::ASSERTION, "Images not loaded after #{timeout}s: #{pending_image.inspect}"
+            raise Capybara::Screenshot::Diff::ASSERTION, "Images have not been loaded after #{timeout}s: #{pending_image.inspect}"
           end
 
           sleep 0.025

--- a/lib/capybara/screenshot/diff/stable_screenshoter.rb
+++ b/lib/capybara/screenshot/diff/stable_screenshoter.rb
@@ -10,9 +10,10 @@ module Capybara
 
         def initialize(capture_options, comparison_options = nil)
           @stability_time_limit, @wait = capture_options.fetch_values(:stability_time_limit, :wait)
-          raise ArgumentError, "wait should be provided" unless @wait
-          raise ArgumentError, "stability_time_limit should be provided for stable screenshots" unless @stability_time_limit
-          raise ArgumentError, "stability_time_limit should be less than wait for stable screenshots" if @stability_time_limit > @wait
+
+          raise ArgumentError, "wait should be provided for stable screenshots" unless wait
+          raise ArgumentError, "stability_time_limit should be provided for stable screenshots" unless stability_time_limit
+          raise ArgumentError, "stability_time_limit (#{stability_time_limit}) should be less or equal than wait (#{wait}) for stable screenshots" unless stability_time_limit <= wait
 
           @comparison_options = comparison_options || Diff.default_options
 
@@ -47,6 +48,7 @@ module Capybara
 
           0.step do |i|
             # Prevents redundant screenshots generations
+            # FIXME: it should be wait, and wait should be replaced with stability_time_limit
             sleep(stability_time_limit) unless i == 0
 
             elapsed_time = last_attempt_at - screenshot_started_at

--- a/lib/capybara/screenshot/diff/stable_screenshoter.rb
+++ b/lib/capybara/screenshot/diff/stable_screenshoter.rb
@@ -10,6 +10,10 @@ module Capybara
 
         def initialize(capture_options, comparison_options = nil)
           @stability_time_limit, @wait = capture_options.fetch_values(:stability_time_limit, :wait)
+          raise ArgumentError, "wait should be provided" unless @wait
+          raise ArgumentError, "stability_time_limit should be provided for stable screenshots" unless @stability_time_limit
+          raise ArgumentError, "stability_time_limit should be less than wait for stable screenshots" if @stability_time_limit > @wait
+
           @comparison_options = comparison_options || Diff.default_options
 
           driver = Diff::Drivers.for(@comparison_options)

--- a/sig/capybara/screenshot/diff/screenshoter.rbs
+++ b/sig/capybara/screenshot/diff/screenshoter.rbs
@@ -36,9 +36,9 @@ module Capybara
 
       def notice_how_to_avoid_this: () -> void
 
-      def prepare_page_for_screenshot: (timeout: Numeric) -> BrowserHelpers::capybara_element?
+      def prepare_page_for_screenshot: (timeout: Numeric?) -> BrowserHelpers::capybara_element?
 
-      def wait_images_loaded: (timeout: Numeric) -> void
+      def wait_images_loaded: (timeout: Numeric?) -> void
 
       private
 

--- a/sig/capybara/screenshot/diff/stable_screenshoter.rbs
+++ b/sig/capybara/screenshot/diff/stable_screenshoter.rbs
@@ -10,6 +10,9 @@ module Capybara
         @screenshoter: (StableScreenshoter | Screenshoter)
         @stability_time_limit: Numeric
 
+        attr_reader stability_time_limit: Numeric?
+        attr_reader wait: Numeric?
+
         def take_comparison_screenshot: (TestMethods::path_entity screenshot_path) -> void
 
         def take_stable_screenshot: (TestMethods::path_entity) -> Pathname?

--- a/sig/capybara/screenshot/diff/stable_screenshoter.rbs
+++ b/sig/capybara/screenshot/diff/stable_screenshoter.rbs
@@ -13,6 +13,8 @@ module Capybara
         attr_reader stability_time_limit: Numeric?
         attr_reader wait: Numeric?
 
+        def initialize: (?Diff::ScreenshotMatcher::capture_options_entity capture_options, ?ScreenshotMatcher::input_options? comparison_options) -> void
+
         def take_comparison_screenshot: (TestMethods::path_entity screenshot_path) -> void
 
         def take_stable_screenshot: (TestMethods::path_entity) -> Pathname?

--- a/test/capybara/screenshot/diff/screenshoter_test.rb
+++ b/test/capybara/screenshot/diff/screenshoter_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "minitest/mock"
+require "capybara/screenshot/diff/drivers/chunky_png_driver"
 
 module Capybara
   module Screenshot
@@ -10,7 +11,7 @@ module Capybara
       include Diff::TestMethodsStub
 
       test "#take_screenshot without wait skips image loading" do
-        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers.for)
+        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers::ChunkyPNGDriver.new)
 
         mock = ::Minitest::Mock.new
         mock.expect(:save_screenshot, true) { |path| path.include?("01_a.png") }
@@ -24,8 +25,10 @@ module Capybara
         mock.verify
       end
 
-      test "#prepare_page_for_screenshot without wait skips image loading" do
-        Screenshoter.new({wait: nil}, Diff::Drivers.for).prepare_page_for_screenshot(timeout: nil)
+      test "#prepare_page_for_screenshot without wait does not raise any error" do
+        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers::ChunkyPNGDriver.new)
+
+        screenshoter.prepare_page_for_screenshot(timeout: nil) # does not raise an error
       end
     end
   end

--- a/test/capybara/screenshot/diff/screenshoter_test.rb
+++ b/test/capybara/screenshot/diff/screenshoter_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "minitest/mock"
-require "capybara/screenshot/diff/drivers/chunky_png_driver"
 
 module Capybara
   module Screenshot
@@ -11,7 +10,7 @@ module Capybara
       include Diff::TestMethodsStub
 
       test "#take_screenshot without wait skips image loading" do
-        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers::ChunkyPNGDriver.new)
+        screenshoter = Screenshoter.new({wait: nil}, ::Minitest::Mock.new)
 
         mock = ::Minitest::Mock.new
         mock.expect(:save_screenshot, true) { |path| path.include?("01_a.png") }
@@ -26,7 +25,7 @@ module Capybara
       end
 
       test "#prepare_page_for_screenshot without wait does not raise any error" do
-        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers::ChunkyPNGDriver.new)
+        screenshoter = Screenshoter.new({wait: nil}, ::Minitest::Mock.new)
 
         screenshoter.prepare_page_for_screenshot(timeout: nil) # does not raise an error
       end

--- a/test/capybara/screenshot/diff/screenshoter_test.rb
+++ b/test/capybara/screenshot/diff/screenshoter_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+module Capybara
+  module Screenshot
+    class ScreenshoterTest < ActionDispatch::IntegrationTest
+      include Diff::TestMethods
+      include Diff::TestMethodsStub
+
+      test "#take_screenshot without wait skips image loading" do
+        screenshoter = Screenshoter.new({wait: nil}, Diff::Drivers.for)
+
+        mock = ::Minitest::Mock.new
+        mock.expect(:save_screenshot, true) { |path| path.include?("01_a.png") }
+
+        BrowserHelpers.stub(:session, mock) do
+          screenshoter.stub(:process_screenshot, true) do
+            screenshoter.take_screenshot(Pathname.new("tmp/01_a.png"))
+          end
+        end
+
+        mock.verify
+      end
+
+      test "#prepare_page_for_screenshot without wait skips image loading" do
+        Screenshoter.new({wait: nil}, Diff::Drivers.for).prepare_page_for_screenshot(timeout: nil)
+      end
+    end
+  end
+end

--- a/test/capybara/screenshot/diff/stable_screenshoter_test.rb
+++ b/test/capybara/screenshot/diff/stable_screenshoter_test.rb
@@ -25,6 +25,18 @@ module Capybara
           mock.verify
         end
 
+        test "#take_stable_screenshot without wait raises any error" do
+          assert_raises ArgumentError, "wait should be provided" do
+            take_stable_screenshot_with("tmp/02_a.png", wait: nil)
+          end
+        end
+
+        test "#take_stable_screenshot without stability_time_limit raises any error" do
+          assert_raises ArgumentError, "stability_time_limit should be provided" do
+            take_stable_screenshot_with("tmp/02_a.png", stability_time_limit: nil)
+          end
+        end
+
         test "#take_comparison_screenshot deletes runtime files on completion" do
           image_compare_stub = build_image_compare_stub
 
@@ -36,7 +48,7 @@ module Capybara
 
           ImageCompare.stub :new, mock do
             StableScreenshoter
-              .new({stability_time_limit: 1, wait: 0.5}, image_compare_stub.driver_options)
+              .new({stability_time_limit: 0.5, wait: 0.5}, image_compare_stub.driver_options)
               .take_comparison_screenshot("tmp/02_a.png")
           end
 
@@ -69,7 +81,7 @@ module Capybara
             ImageCompare.stub :new, mock do
               # Wait time is less then stability time, which will generate problem
               StableScreenshoter
-                .new({stability_time_limit: 1, wait: 0.5}, build_image_compare_stub(equal: false).driver_options)
+                .new({stability_time_limit: 0.5, wait: 0.5}, build_image_compare_stub(equal: false).driver_options)
                 .take_comparison_screenshot(screenshot_path.to_s)
             end
           end


### PR DESCRIPTION
I'm getting the exception below intermittently when running my tests. The problem is at `screenshoter.rb:119` the `timeout` is `nil` because of this:

```ruby
# stable_screenshoter.rb:16 removing :wait from capture_options here
@screenshoter = Diff.screenshoter.new(capture_options.except(*STABILITY_OPTIONS), driver)
```

I think when I run locally `pending_image` is `nil` so the tests pass, but on CircleCI it's non-`nil` thus the intermittent failure. That is, `timeout` is never checked locally.

@pftg Should `wait` really be excluded from that `capture_options`?

```
     Failure/Error:
       screenshot "with_ocr_modal_open",
                  tolerance: success_alert_tolerance,
                  skip_area: skip_area
     
     ArgumentError:
       comparison of Float with nil failed
     
     [Screenshot Image]: /home/circleci/app/tmp/capybara/failures_r_spec_example_groups_the_new_admin_order_line_items_page_with_featurereceiptocr_enabled_shows_usable_ocr_data_179.png

     [Screenshot HTML]: /home/circleci/app/tmp/capybara/failures_r_spec_example_groups_the_new_admin_order_line_items_page_with_featurereceiptocr_enabled_shows_usable_ocr_data_179.html

     
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:119:in `>='
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:119:in `block in wait_images_loaded'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:115:in `loop'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:115:in `wait_images_loaded'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:100:in `prepare_page_for_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshoter.rb:55:in `take_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/stable_screenshoter.rb:53:in `block in take_stable_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/stable_screenshoter.rb:44:in `step'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/stable_screenshoter.rb:44:in `take_stable_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/stable_screenshoter.rb:23:in `take_comparison_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshot_matcher.rb:82:in `take_comparison_screenshot'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/screenshot_matcher.rb:54:in `build_screenshot_matches_job'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/****_methods.rb:119:in `build_screenshot_matches_job'
     # ./*************/ruby/3.2.0/bundler/gems/capybara-screenshot-diff-116a7c52d529/lib/capybara/screenshot/diff/****_methods.rb:73:in `screenshot'
     # ./spec/system/admin/orders/jp_line_items_page_spec.rb:554:in `block (3 levels) in <top (required)>'
```