### PR TITLE
Full page screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,17 @@ You can specify the format of the screenshots taken by setting the `screenshot_f
 Capybara::Screenshot.screenshot_format = "webp"
 ```
 
+### Customize Capybara#screenshot options
+
+Allow to bypass screenshot options to Capybara driver.
+
+```ruby
+# To create full page screenshots for Selenium
+Capybara::Screenshot.capybara_screenshot_options[:full_page] = true
+
+screenshot('index', median_filter_window_size: 2, capybara_screenshot_options: {full_page: false})
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.

--- a/lib/capybara/screenshot/diff.rb
+++ b/lib/capybara/screenshot/diff.rb
@@ -22,6 +22,7 @@ module Capybara
     mattr_accessor(:save_path) { "doc/screenshots" }
     mattr_accessor(:use_lfs)
     mattr_accessor(:screenshot_format) { "png" }
+    mattr_accessor(:capybara_screenshot_options) { {} }
 
     class << self
       def root=(path)
@@ -70,6 +71,7 @@ module Capybara
           color_distance_limit: color_distance_limit,
           driver: driver,
           screenshot_format: Screenshot.screenshot_format,
+          capybara_screenshot_options: Screenshot.capybara_screenshot_options,
           shift_distance_limit: shift_distance_limit,
           skip_area: skip_area,
           stability_time_limit: Screenshot.stability_time_limit,

--- a/lib/capybara/screenshot/diff/screenshot_matcher.rb
+++ b/lib/capybara/screenshot/diff/screenshot_matcher.rb
@@ -44,10 +44,11 @@ module Capybara
           return if Capybara::Screenshot::Diff.fail_if_new && !base_screenshot_path.exist?
 
           capture_options = {
+            capybara_screenshot_options: driver_options[:capybara_screenshot_options],
             crop: driver_options.delete(:crop),
+            screenshot_format: driver_options[:screenshot_format],
             stability_time_limit: driver_options.delete(:stability_time_limit),
-            wait: driver_options.delete(:wait),
-            screenshot_format: driver_options[:screenshot_format]
+            wait: driver_options.delete(:wait)
           }
 
           # Load new screenshot from Browser

--- a/lib/capybara/screenshot/diff/screenshoter.rb
+++ b/lib/capybara/screenshot/diff/screenshoter.rb
@@ -26,6 +26,10 @@ module Capybara
         @capture_options[:screenshot_format] || "png"
       end
 
+      def capybara_screenshot_options
+        @capture_options[:capybara_screenshot_options] || {}
+      end
+
       def self.attempts_screenshot_paths(base_file)
         extname = Pathname.new(base_file).extname
         Dir["#{base_file.to_s.chomp(extname)}.attempt_*#{extname}"].sort
@@ -51,12 +55,14 @@ module Capybara
         screenshot_path.sub_ext(format(".attempt_%02i#{screenshot_path.extname}", iteration))
       end
 
+      PNG_EXTENSION = ".png"
+
       def take_screenshot(screenshot_path)
         blurred_input = prepare_page_for_screenshot(timeout: wait)
 
         # Take browser screenshot and save
-        tmpfile = Tempfile.new([screenshot_path.basename.to_s, ".png"])
-        BrowserHelpers.session.save_screenshot(tmpfile.path)
+        tmpfile = Tempfile.new([screenshot_path.basename.to_s, PNG_EXTENSION])
+        BrowserHelpers.session.save_screenshot(tmpfile.path, **capybara_screenshot_options)
 
         # Load saved screenshot and pre-process it
         process_screenshot(tmpfile.path, screenshot_path)

--- a/sig/capybara/screenshot/diff/screenshot_matcher.rbs
+++ b/sig/capybara/screenshot/diff/screenshot_matcher.rbs
@@ -10,6 +10,7 @@ module Capybara
         attr_reader base_screenshot_path: TestMethods::path_entity
         attr_reader driver_options: Drivers::BaseDriver::options_entity
         attr_reader screenshot_format: String
+        attr_reader capybara_screenshot_options: top?
         attr_reader screenshot_full_name: TestMethods::path_entity
         attr_reader screenshot_path: Pathname
 

--- a/test/capybara/screenshot/diff/screenshoter_test.rb
+++ b/test/capybara/screenshot/diff/screenshoter_test.rb
@@ -24,6 +24,24 @@ module Capybara
         mock.verify
       end
 
+      test "#take_screenshot with custom screenshot options" do
+        screenshoter = Screenshoter.new(
+          {wait: nil, capybara_screenshot_options: {full: true}},
+          ::Minitest::Mock.new
+        )
+
+        mock = ::Minitest::Mock.new
+        mock.expect(:save_screenshot, true) { |path, options| path.include?("01_a.png") && options[:full] }
+
+        BrowserHelpers.stub(:session, mock) do
+          screenshoter.stub(:process_screenshot, true) do
+            screenshoter.take_screenshot(Pathname.new("tmp/01_a.png"))
+          end
+        end
+
+        mock.verify
+      end
+
       test "#prepare_page_for_screenshot without wait does not raise any error" do
         screenshoter = Screenshoter.new({wait: nil}, ::Minitest::Mock.new)
 


### PR DESCRIPTION
I'm currently evaluating adding this gem for visual regression testing. Thank you for all your work. I was quite worried about the image diffing until I found this gem 🙇.

Most of our screenshots are of different heights. We can just set a rather high screen height. But that would be adding a lot of whitespace to many of the images, and might require the occasional tweaking.

I've seen in the Selenium API that it's possible to send `full_page: true` as an option to [`save_screenshot`](https://www.rubydoc.info/gems/selenium-webdriver/Selenium/WebDriver/TakesScreenshot#save_screenshot-instance_method). Would you welcome a patch where we add it to the `screenshot`-`options` -> `capture_options` -> `Screenshoter#browser_save_screenshot` -> Capybara/Selenium?

(Some more background: Unfortunately, this feature does not currently work in Chrome. [This closed issue](https://github.com/SeleniumHQ/selenium/issues/8705) is the closest to a reason I have found.)