### PR TITLE
Remove Lightpanda browser usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@
 FROM jetthoughts/cimg-ruby:4.0-chrome
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    BUNDLE_PATH=/bundle \
-    LIGHTPANDA_DISABLE_TELEMETRY=true
+    BUNDLE_PATH=/bundle
 
 # Install system dependencies with cached apt
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -41,11 +40,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libxml2-dev \
       swig && \
     sudo rm -rf /var/lib/apt/lists/*
-
-# Install Lightpanda browser (experimental CDP-compatible headless browser)
-RUN sudo curl -L -o /usr/local/bin/lightpanda \
-      https://github.com/lightpanda-io/browser/releases/download/nightly/lightpanda-x86_64-linux && \
-    sudo chmod a+x /usr/local/bin/lightpanda
 
 # Setup directories and fix font config if file exists
 RUN sudo mkdir -p /bundle /tmp/.X11-unix && \

--- a/README.md
+++ b/README.md
@@ -688,16 +688,6 @@ RECORD_SCREENSHOTS=1 bin/dtest
 
 This skips screenshot comparisons and saves new baselines instead. Without this step, tests will fail because your local browser renders pixels differently from the previously committed baselines.
 
-#### Experimental: Lightpanda browser
-
-[Lightpanda](https://github.com/lightpanda-io/browser) is included as an experimental CDP-based headless browser. It can be enabled for the `cuprite` driver:
-
-```bash
-ENABLE_LIGHTPANDA=1 bin/dtest
-```
-
-**Note:** Lightpanda's CDP support does not yet cover viewport resizing or full execution context management, so screenshot comparison tests may fail. This is gated behind the env var until Lightpanda matures.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/dtest
+++ b/bin/dtest
@@ -7,7 +7,7 @@ export DOCKER_DEFAULT_PLATFORM=linux/amd64
 # Define allowed environment variables to pass to Docker
 ALLOWED_ENV_VARS=(
   "CI" "DEBUG" "TEST_ENV" "RAILS_ENV" "RACK_ENV" "COVERAGE" "DISABLE_ROLLBACK_COMPARISON_RUNTIME_FILES"
-  "RECORD_SCREENSHOTS" "TEST" "TESTOPTS" "SCREENSHOT_DRIVER" "ENABLE_LIGHTPANDA"
+  "RECORD_SCREENSHOTS" "TEST" "TESTOPTS" "SCREENSHOT_DRIVER"
 )
 
 # Build the Docker env args string
@@ -29,15 +29,7 @@ echo "Running tests..."
 DRIVERS=("cuprite" "selenium_chrome_headless" "selenium_headless")
 for driver in "${DRIVERS[@]}"; do
   echo "Running tests with $driver driver..."
-  if [[ "$driver" == "cuprite" && -n "$ENABLE_LIGHTPANDA" ]]; then
-    docker run $DOCKER_ENV_ARGS \
-      -e CAPYBARA_DRIVER="$driver" \
-      -e LIGHTPANDA_URL="ws://127.0.0.1:9222" \
-      -v ${PWD}:/app -v csd-bundle-cache:/bundle --rm -t csd:test \
-      bash -c 'lightpanda serve --host 127.0.0.1 --port 9222 & sleep 1 && bin/rake test "$@"' _ "$@" || exit 1
-  else
-    docker run $DOCKER_ENV_ARGS -e CAPYBARA_DRIVER="$driver" \
-      -v ${PWD}:/app -v csd-bundle-cache:/bundle --rm -t csd:test \
-      bin/rake test "$@" || exit 1
-  fi
+  docker run $DOCKER_ENV_ARGS -e CAPYBARA_DRIVER="$driver" \
+    -v ${PWD}:/app -v csd-bundle-cache:/bundle --rm -t csd:test \
+    bin/rake test "$@" || exit 1
 done

--- a/test/support/setup_capybara_drivers.rb
+++ b/test/support/setup_capybara_drivers.rb
@@ -69,14 +69,9 @@ if ENV["CAPYBARA_DRIVER"] == "cuprite"
     process_timeout: ENV["CI"] ? 40 : 5,
     screen_size: SCREEN_SIZE,
     timeout: ENV["CI"] ? 40 : 5,
-    window_size: SCREEN_SIZE
+    window_size: SCREEN_SIZE,
+    browser_options: CHROME_ARGS
   }
-
-  if ENV["LIGHTPANDA_URL"]
-    cuprite_options[:url] = ENV["LIGHTPANDA_URL"]
-  else
-    cuprite_options[:browser_options] = CHROME_ARGS
-  end
 
   Capybara.register_driver(:cuprite) do |app|
     Capybara::Cuprite::Driver.new(app, **cuprite_options)


### PR DESCRIPTION
## Summary

Removes all Lightpanda browser integration from the project. Lightpanda was an experimental CDP-based headless browser that is no longer needed.

## Changes

- **Dockerfile**: Removed `LIGHTPANDA_DISABLE_TELEMETRY` env var and lightpanda installation step
- **bin/dtest**: Removed `ENABLE_LIGHTPANDA` from allowed env vars and simplified test driver loop
- **test/support/setup_capybara_drivers.rb**: Removed `LIGHTPANDA_URL` conditional, always uses Chrome browser options for cuprite
- **README.md**: Removed experimental Lightpanda documentation section

## Impact

The cuprite driver now always runs with standard Chrome headless options. No functional change for existing users who didn't use `ENABLE_LIGHTPANDA=1`.

## Summary by Sourcery

Remove the experimental Lightpanda browser integration and standardize cuprite on Chrome-based headless execution.

Enhancements:
- Clean up test runner configuration to drop Lightpanda-related environment variables and logic.

Build:
- Remove Lightpanda installation and telemetry environment variable from the Docker image.

Documentation:
- Delete the README section describing the experimental Lightpanda browser usage.

Tests:
- Simplify cuprite driver setup to always use standard Chrome browser options instead of Lightpanda-specific configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Lightpanda experimental headless browser support from Docker image, test runner configuration, and Cuprite browser driver setup. This reduces Docker image size and streamlines the test execution pipeline for all supported drivers.

* **Documentation**
  * Removed Lightpanda feature documentation from README, including setup instructions, environment variable configuration, and known screenshot comparison limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->