### PR TITLE
refactor: flatten VipsUtil and merge null builders

### DIFF
--- a/lib/capybara/screenshot/diff/drivers/vips_driver.rb
+++ b/lib/capybara/screenshot/diff/drivers/vips_driver.rb
@@ -19,8 +19,8 @@ module Capybara
           def find_difference_region(comparison)
             new_image, base_image, options = comparison.new_image, comparison.base_image, comparison.options
 
-            diff_mask = VipsUtil.difference_mask(base_image, new_image, options[:color_distance_limit])
-            region = VipsUtil.difference_region_by(diff_mask)
+            diff_mask = self.class.difference_mask(base_image, new_image, options[:color_distance_limit])
+            region = self.class.difference_region_by(diff_mask)
             # TODO: schedule research when we got this case for VIPs
             # region = nil if region && region_covers_entire_image?(region, base_image)
 
@@ -55,7 +55,7 @@ module Capybara
           end
 
           def difference_level(diff_mask, old_img, _region = nil)
-            VipsUtil.difference_area_size_by(diff_mask).to_f / image_area_size(old_img)
+            self.class.difference_area_size_by(diff_mask).to_f / image_area_size(old_img)
           end
 
           MAX_FILENAME_LENGTH = 200
@@ -115,24 +115,23 @@ module Capybara
               region.width == width_for(base_image)
           end
 
-          class VipsUtil
-            def self.difference_area(old_image, new_image, color_distance: 0)
-              difference_mask = difference_mask(new_image, old_image, color_distance)
-              difference_area_size_by(difference_mask)
+          class << self
+            def difference_area(old_image, new_image, color_distance: 0)
+              mask = difference_mask(new_image, old_image, color_distance)
+              difference_area_size_by(mask)
             end
 
-            def self.difference_area_size_by(difference_mask)
+            def difference_area_size_by(difference_mask)
               diff_mask = difference_mask == 0
               diff_mask.hist_find.to_a[0][0].max
             end
 
-            def self.difference_mask(base_image, new_image, color_distance = nil)
+            def difference_mask(base_image, new_image, color_distance = nil)
               result = (new_image - base_image).abs
-
               color_distance ? result > color_distance : result
             end
 
-            def self.difference_region_by(diff_mask)
+            def difference_region_by(diff_mask)
               columns, rows = diff_mask.bandor.project
 
               left = columns.profile[1].min

--- a/lib/capybara/screenshot/diff/image_compare.rb
+++ b/lib/capybara/screenshot/diff/image_compare.rb
@@ -168,12 +168,9 @@ module Capybara
           image_preprocessor.process_comparison(comparison)
         end
 
-        def build_null_difference(failed_by = nil, comparison = nil)
-          Difference.build_null(comparison || build_null_comparison, base_image_path, image_path, failed_by)
-        end
-
-        def build_null_comparison
-          Comparison.new(nil, nil, driver_options, driver, image_path, base_image_path).freeze
+        def build_null_difference(failed_by = nil)
+          comparison = Comparison.new(nil, nil, driver_options, driver, image_path, base_image_path).freeze
+          Difference.build_null(comparison, base_image_path, image_path, failed_by)
         end
 
         # Check if both images exist

--- a/test/unit/drivers/vips_driver_test.rb
+++ b/test/unit/drivers/vips_driver_test.rb
@@ -166,8 +166,8 @@ module Capybara
           end
         end
 
-        class VipsUtilTest < ActiveSupport::TestCase
-          test "VipsUtil.difference_region_by detects difference regions without color threshold" do
+        class VipsDriverClassMethodsTest < ActiveSupport::TestCase
+          test "VipsDriver.difference_region_by detects difference regions without color threshold" do
             old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
             new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
 
@@ -180,7 +180,7 @@ module Capybara
             assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
           end
 
-          test "VipsUtil.difference_region_by respects color_distance threshold" do
+          test "VipsDriver.difference_region_by respects color_distance threshold" do
             old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
             new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/b.png")
 
@@ -189,7 +189,7 @@ module Capybara
             assert_equal [26.0, 18.0, 27.0, 19.0], [left, top, right, bottom]
           end
 
-          test "VipsUtil.difference_region_by returns correct region coordinates" do
+          test "VipsDriver.difference_region_by returns correct region coordinates" do
             old_image = Vips::Image.new_from_file(TEST_IMAGES_DIR.join("a.png").to_path)
             new_image = Vips::Image.new_from_file(TEST_IMAGES_DIR.join("b.png").to_path)
 
@@ -198,18 +198,18 @@ module Capybara
             assert_equal [20.0, 15.0, 30.0, 25.0], [left, top, right, bottom]
           end
 
-          test "VipsUtil.difference_area calculates correct area of difference" do
+          test "VipsDriver.difference_area calculates correct area of difference" do
             old_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/a.png")
             new_image = Vips::Image.new_from_file("#{TEST_IMAGES_DIR}/d.png").bandjoin(255)
 
-            assert_equal 8, VipsDriver::VipsUtil.difference_area(old_image, new_image, color_distance: 10)
+            assert_equal 8, VipsDriver.difference_area(old_image, new_image, color_distance: 10)
           end
 
           private
 
           def difference(old_image, new_image, color_distance: nil)
-            diff_mask = VipsDriver::VipsUtil.difference_mask(new_image, old_image, color_distance)
-            VipsDriver::VipsUtil.difference_region_by(diff_mask).to_edge_coordinates
+            diff_mask = VipsDriver.difference_mask(new_image, old_image, color_distance)
+            VipsDriver.difference_region_by(diff_mask).to_edge_coordinates
           end
         end
       end


### PR DESCRIPTION
## Summary
- Flatten `VipsUtil` nested class into `VipsDriver` class methods — removes unnecessary nesting
- Merge `build_null_comparison` + `build_null_difference` into single method — two methods that always composed together

## Test plan
- [x] Unit tests pass (158 runs, 0 failures)
- [x] Full suite passes with `CI=true` (184 runs, 0 failures)
- [x] No public API changes
- [x] `VipsDriver.difference_mask` etc. still accessible as class methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor VIPS image diff utilities into VipsDriver class methods and simplify null difference construction in image comparison.

Enhancements:
- Flatten the VipsUtil helper into VipsDriver class-level methods for computing image differences and regions.
- Simplify null difference handling by constructing the null comparison inline within build_null_difference.

Tests:
- Update VipsDriver tests to target the new class-level APIs instead of the removed VipsUtil helper.