### PR TITLE
feat: add Diff.compare for standalone image comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ end
 | Standard Rails apps | 0.0005 | 15 | 1s |
 | Pixel-perfect design tests | 0.0001 | 5 | 1s |
 
+### Standalone image comparison
+
+Compare any two images without Capybara or a browser — useful for PDF regression, generated images, or CI artifact validation:
+
+```ruby
+result = Capybara::Screenshot::Diff.compare("baseline.png", "current.png")
+result.quick_equal?  # => true if byte-identical
+result.different?    # => true if visually different (respects tolerance)
+
+# With options
+result = Capybara::Screenshot::Diff.compare("baseline.pdf.png", "current.pdf.png",
+  driver: :vips,
+  tolerance: 0.001,
+  perceptual_threshold: 2.0
+)
+```
+
 ### Perceptual color comparison (VIPS only)
 
 By default, color differences are measured using raw RGB channel distance. This can produce

--- a/lib/capybara_screenshot_diff.rb
+++ b/lib/capybara_screenshot_diff.rb
@@ -90,6 +90,10 @@ module Capybara
         yield Screenshot, self
       end
 
+      def self.compare(baseline_path, current_path, **options)
+        ImageCompare.new(current_path, baseline_path, default_options.merge(options))
+      end
+
       def self.default_options
         {
           area_size_limit: area_size_limit,

--- a/test/unit/compare_api_test.rb
+++ b/test/unit/compare_api_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Capybara
+  module Screenshot
+    module Diff
+      class CompareApiTest < ActiveSupport::TestCase
+        test ".compare returns ImageCompare instance" do
+          result = Diff.compare(
+            TEST_IMAGES_DIR / "a.png",
+            TEST_IMAGES_DIR / "a.png"
+          )
+          assert_kind_of ImageCompare, result
+        end
+
+        test ".compare detects identical images" do
+          result = Diff.compare(
+            TEST_IMAGES_DIR / "a.png",
+            TEST_IMAGES_DIR / "a.png"
+          )
+          assert result.quick_equal?
+          assert_not result.different?
+        end
+
+        test ".compare detects different images" do
+          result = Diff.compare(
+            TEST_IMAGES_DIR / "a.png",
+            TEST_IMAGES_DIR / "b.png"
+          )
+          assert_not result.quick_equal?
+          assert result.different?
+        end
+
+        test ".compare accepts driver option" do
+          skip "VIPS not present" unless defined?(Vips)
+
+          result = Diff.compare(
+            TEST_IMAGES_DIR / "a.png",
+            TEST_IMAGES_DIR / "a.png",
+            driver: :vips
+          )
+          assert result.quick_equal?
+        end
+
+        test ".compare accepts tolerance options" do
+          skip "VIPS not present" unless defined?(Vips)
+
+          result = Diff.compare(
+            TEST_IMAGES_DIR / "a.png",
+            TEST_IMAGES_DIR / "b.png",
+            driver: :vips,
+            tolerance: 1.0
+          )
+          assert_not result.different?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Browser-independent API for comparing any two images:
```ruby
result = Capybara::Screenshot::Diff.compare("baseline.png", "current.png")
result.quick_equal?  # byte-identical?
result.different?    # visually different?
```

Supports all options: driver, tolerance, perceptual_threshold, color_distance_limit.

Based on real usage from corsis/pet which uses the gem for PDF visual regression.

## Test plan
- [x] 5 tests: return type, identical, different, driver option, tolerance
- [x] Full suite with CI=true (196 runs, 0 failures)
- [x] Pre-PR: brutal review (0.5, clean) + codex review (arg order fix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a public Diff.compare API for standalone image comparison without Capybara or a browser.

New Features:
- Introduce Diff.compare helper for comparing any two image files using existing diff logic and options.

Enhancements:
- Document standalone image comparison usage and options in the README.

Tests:
- Add unit tests covering Diff.compare return type, identical and different images, and option handling for driver and tolerance.