### PR TITLE
fix: remove ActiveSupport dependency from fail_if_new default

### DIFF
--- a/lib/capybara_screenshot_diff.rb
+++ b/lib/capybara_screenshot_diff.rb
@@ -63,7 +63,7 @@ module Capybara
     module Diff
       mattr_accessor(:delayed) { true }
       mattr_accessor :area_size_limit
-      mattr_accessor(:fail_if_new) { ENV["CI"].present? }
+      mattr_accessor(:fail_if_new) { !ENV["CI"].nil? && !ENV["CI"].empty? }
       mattr_accessor(:fail_on_difference) { true }
       mattr_accessor :color_distance_limit
       mattr_accessor(:enabled) { true }


### PR DESCRIPTION
## Summary

`ENV["CI"].present?` crashes with `NoMethodError: undefined method 'present?' for nil` when the gem is loaded before ActiveSupport core extensions (e.g., in non-Rails projects or projects that load gems before Rails).

Replace with plain Ruby: `!ENV["CI"].nil? && !ENV["CI"].empty?`

## Found by
Real-world integration testing with jetthoughts.github.io (Hugo static site with Capybara screenshot tests).

## Test plan
- [x] Unit tests pass (175 runs, 0 failures)  
- [x] jetthoughts.github.io tests pass (26 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent NoMethodError when loading the gem in environments without ActiveSupport by avoiding use of present? on ENV["CI"].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated environment variable detection logic for CI environment compatibility. The change simplifies how the system determines whether to fail on new screenshots, removing dependency on Rails-specific helper methods in favor of explicit standard checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->