### PR TITLE
fix: quick wins — Quick Start, error messages, RSpec matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ end
 | Standard Rails apps | 0.0005 | 15 | 1s |
 | Pixel-perfect design tests | 0.0001 | 5 | 1s |
 
+### Configuration Tiers
+
+**Tier 1 — Zero config (works immediately):**
+`blur_active_element`, `hide_caret`, and `fail_if_new` (in CI) are enabled by default.
+Just `require 'capybara_screenshot_diff/minitest'` and call `screenshot`.
+
+**Tier 2 — Set when tests are flaky:**
+
+| Setting | When to use |
+|---------|-------------|
+| `window_size` | Screenshots differ between machines due to different browser sizes |
+| `tolerance` | Sub-pixel rendering differences cause false positives |
+| `skip_area` | Dynamic content (timestamps, ads) changes between runs |
+| `stability_time_limit` | Animations or loading states cause inconsistent captures |
+
+**Tier 3 — Advanced tuning:**
+
+| Setting | When to use |
+|---------|-------------|
+| `perceptual_threshold` | Anti-aliasing false positives across OS/browser versions |
+| `shift_distance_limit` | Content shifts by a few pixels (ChunkyPNG only) |
+| `area_size_limit` | Allow small diff regions below a pixel count |
+| `color_distance_limit` | Fine-tune raw RGB channel tolerance |
+| `median_filter_window_size` | Smooth noise before comparison (VIPS only) |
+
 ### Standalone image comparison
 
 Compare any two images without Capybara or a browser — useful for PDF regression, generated images, or CI artifact validation:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ Ever introduced a graphical change unintended?  Never want it to happen again?
 Then this gem is for you!  Use this gem to detect changes in your pages by
 taking screen shots and comparing them to the previous revision.
 
+## Quick Start (60 seconds)
+
+```ruby
+# 1. Add to Gemfile
+gem 'capybara-screenshot-diff'
+
+# 2. Add to test/test_helper.rb
+require 'capybara_screenshot_diff/minitest'
+
+# 3. In any system test
+class MyTest < ActionDispatch::SystemTestCase
+  include CapybaraScreenshotDiff::DSL
+  include CapybaraScreenshotDiff::Minitest::Assertions
+
+  test "homepage" do
+    visit "/"
+    screenshot "homepage"  # First run: saves baseline. Next runs: compares.
+  end
+end
+```
+
+That's it. Screenshots are saved to `doc/screenshots/` and compared against the committed version on each test run.
+
 ## Features
 
 - **Screenshot Capturing**: Easily capture screenshots at any point in your tests to track the visual state of your application.

--- a/README.md
+++ b/README.md
@@ -827,6 +827,30 @@ CapybaraScreenshotDiff.reporters << MyReporter.new
 
 Reporters are notified before assertions are cleared on each test teardown. `finalize` is called via `at_exit`.
 
+## Troubleshooting
+
+**"No existing screenshot found"**
+First run creates baselines. Record them: `RECORD_SCREENSHOTS=1 bundle exec rake test`.
+In CI, `fail_if_new` is `true` by default — commit your baselines first.
+
+**Screenshots differ between CI and local**
+Font rendering varies across OS versions. Use `tolerance: 0.001` or `perceptual_threshold: 2.0`
+to ignore sub-pixel differences. Set `window_size` to ensure consistent browser dimensions.
+
+**Animations cause flaky diffs**
+Set `stability_time_limit: 1` to wait for the page to stabilize before capturing.
+The gem takes multiple screenshots and compares them until two consecutive ones match.
+
+**Dynamic content (timestamps, ads) always differs**
+Use `skip_area` to ignore specific regions:
+```ruby
+screenshot "dashboard", skip_area: [".timestamp", "#ad-banner"]
+```
+
+**Screenshot assertion didn't seem to run**
+Check that `Capybara::Screenshot.enabled` is not `false`. With `delayed: true` (default),
+comparisons run in `before_teardown`, not inline — errors appear after the test body.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.

--- a/lib/capybara/screenshot/diff/screenshot_matcher.rb
+++ b/lib/capybara/screenshot/diff/screenshot_matcher.rb
@@ -74,7 +74,8 @@ module Capybara
           if Capybara::Screenshot::Diff.fail_if_new && !@snapshot.base_path.exist?
             raise CapybaraScreenshotDiff::ExpectationNotMet.new(<<~ERROR.chomp, caller)
               No existing screenshot found for #{@snapshot.base_path}!
-              To stop seeing this error disable by `Capybara::Screenshot::Diff.fail_if_new=false`
+              To record baselines: RECORD_SCREENSHOTS=1 bundle exec rake test
+              To allow new screenshots: Capybara::Screenshot::Diff.fail_if_new = false
             ERROR
           end
         end

--- a/lib/capybara_screenshot_diff/rspec.rb
+++ b/lib/capybara_screenshot_diff/rspec.rb
@@ -4,11 +4,19 @@ require "rspec/core"
 require "capybara_screenshot_diff/dsl"
 
 RSpec::Matchers.define :match_screenshot do |name, **options|
-  description { "match a screenshot" }
+  description { "match screenshot '#{name}'" }
 
   match do |_page|
     screenshot(name, **options)
     true
+  end
+
+  failure_message do
+    "Expected page to match screenshot '#{name}'"
+  end
+
+  failure_message_when_negated do
+    "Expected page not to match screenshot '#{name}'"
   end
 end
 


### PR DESCRIPTION
## Summary
- **TW1:** Add 60-second Quick Start to README top — complete working example before feature list
- **TW2:** Add recording instructions to missing baseline error message
- **TW4+TW6:** Add `failure_message` and `description` to RSpec `match_screenshot` matcher

## Test plan
- [x] Full suite with CI=true (201 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve onboarding, error guidance, and RSpec matcher usability for capybara-screenshot-diff.

Enhancements:
- Clarify the missing baseline screenshot error message with instructions for recording baselines and allowing new screenshots.
- Enhance the RSpec match_screenshot matcher with custom failure messaging and description for clearer test output.

Documentation:
- Add a 60-second Quick Start example to the top of the README with a minimal working Minitest setup.