### PR TITLE
chore: prepare v1.12.0 release with streamlined release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,62 @@
 ---
+name: Release
+
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., 1.12.0)"
+        required: true
+        type: string
 
 jobs:
-  push:
-    name: Push gem to RubyGems.org
+  release:
+    name: Release v${{ github.event.inputs.version }}
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+      id-token: write
+      contents: write
 
     steps:
-      # Set up
       - uses: actions/checkout@v6
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ruby
 
-      # Release
-      - uses: rubygems/release-gem@v1
+      - name: Verify version
+        run: |
+          GEM_VERSION="${{ github.event.inputs.version }}"
+          CODE_VERSION=$(ruby -rlib/capybara/screenshot/diff/version -e "puts Capybara::Screenshot::Diff::VERSION")
+          if [ "$GEM_VERSION" != "$CODE_VERSION" ]; then
+            echo "Version mismatch: input=$GEM_VERSION code=$CODE_VERSION"
+            exit 1
+          fi
+
+      - name: Test
+        run: bundle exec rake test
+
+      - name: Create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ github.event.inputs.version }}" -m "v${{ github.event.inputs.version }}"
+          git push origin "v${{ github.event.inputs.version }}"
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ github.event.inputs.version }}"
+          name: "v${{ github.event.inputs.version }}"
+          body: |
+            ## What's Changed
+
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md#v${{ github.event.inputs.version }}) for full details.
+
+            **Upgrade Guide:** [docs/UPGRADING.md](https://github.com/${{ github.repository }}/blob/main/docs/UPGRADING.md)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.12.0] - 2026-04-12
+
+### Added
+- HTML reporter for visual diff dashboard with premium UI, side-by-side comparison, and search ([#861183f](https://github.com/snap-diff/snap_diff-capybara/commit/861183f), [#993bcb9](https://github.com/snap-diff/snap_diff-capybara/commit/993bcb9))
+- `Diff.compare` for standalone image comparison without Capybara or browser ([#1364048](https://github.com/snap-diff/snap_diff-capybara/commit/1364048))
+- Perceptual color distance (dE00) support to VipsDriver for anti-aliasing tolerance ([#ce01d98](https://github.com/snap-diff/snap_diff-capybara/commit/ce01d98))
+- `assert_no_screenshot_changes` to DSL for asserting no visual regressions ([#6d7e1a6](https://github.com/snap-diff/snap_diff-capybara/commit/6d7e1a6))
+- `Diff.configure` block helper for simplified one-place configuration ([#5ffec5d](https://github.com/snap-diff/snap_diff-capybara/commit/5ffec5d))
+- Ruby 3.5 support in CI ([#359b4e4](https://github.com/snap-diff/snap_diff-capybara/commit/359b4e4))
+- Lightpanda browser as experimental CDP alternative to Chrome ([#ed59add](https://github.com/snap-diff/snap_diff-capybara/commit/ed59add))
+
+### Changed
+- `blur_active_element` now defaults to `true` to prevent cursor blinking artifacts ([#d60c30f](https://github.com/snap-diff/snap_diff-capybara/commit/d60c30f))
+- `hide_caret` now defaults to `true` for stable screenshots ([#d60c30f](https://github.com/snap-diff/snap_diff-capybara/commit/d60c30f))
+- `fail_if_new` now defaults to `true` in CI environments (when `ENV['CI']` is set) ([#715fa1b](https://github.com/snap-diff/snap_diff-capybara/commit/715fa1b))
+- HTML report redesigned with premium UI and visual testing capabilities ([#993bcb9](https://github.com/snap-diff/snap_diff-capybara/commit/993bcb9))
+
+### Deprecated
+- SVN support removed — use Git for version control ([#2fe2792](https://github.com/snap-diff/snap_diff-capybara/commit/2fe2792))
+
+### Removed
+- SVN support completely removed ([#2fe2792](https://github.com/snap-diff/snap_diff-capybara/commit/2fe2792))
+- `CaptureStrategy` layer inlined into `ScreenshotCoordinator` (internal refactoring) ([#7c3dcf7](https://github.com/snap-diff/snap_diff-capybara/commit/7c3dcf7))
+- `ComparisonLoader` inlined into `ImageCompare` (internal refactoring) ([#2906681](https://github.com/snap-diff/snap_diff-capybara/commit/2906681))
+- `ImagePreprocessor#call` method removed (was dead code) ([#c2023c5](https://github.com/snap-diff/snap_diff-capybara/commit/c2023c5))
+
+### Fixed
+- Remove ActiveSupport runtime dependency (`.presence` → plain Ruby) for lighter installations ([#e3b1a2e](https://github.com/snap-diff/snap_diff-capybara/commit/e3b1a2e))
+- Remove ActiveSupport dependency from `fail_if_new` default ([#a960612](https://github.com/snap-diff/snap_diff-capybara/commit/a960612))
+- Add `failure_message` and description to RSpec matcher for better error output ([#9550153](https://github.com/snap-diff/snap_diff-capybara/commit/9550153))
+- Add recording instructions to missing baseline error ([#1b73136](https://github.com/snap-diff/snap_diff-capybara/commit/1b73136))
+- Handle extensionless files in reporter filename generation ([#50191f6](https://github.com/snap-diff/snap_diff-capybara/commit/50191f6))
+- Prevent nil crash in tempfile cleanup ([#444ac30](https://github.com/snap-diff/snap_diff-capybara/commit/444ac30))
+- Reset `fail_if_new` in test setup for CI compatibility ([#5e4f8b1](https://github.com/snap-diff/snap_diff-capybara/commit/5e4f8b1))
+- Remove misleading `filter_image_with_median` from ChunkyPNGDriver ([#567df71](https://github.com/snap-diff/snap_diff-capybara/commit/567df71))
+- Freeze options hash and widen rescue in `files_identical?` ([#3331012](https://github.com/snap-diff/snap_diff-capybara/commit/3331012))
+- Use `FileUtils.compare_file` for byte content comparison ([#16a776e](https://github.com/snap-diff/snap_diff-capybara/commit/16a776e))
+- Resolve setup ordering issue with DSLStub in Ruby 4.0 ([#be53abb](https://github.com/snap-diff/snap_diff-capybara/commit/be53abb))
+- Resolve Ruby 4.0 compatibility issues in CI ([#18d5564](https://github.com/snap-diff/snap_diff-capybara/commit/18d5564))
+- Prevent skipping big changes in tolerance calculation ([#1d57a61](https://github.com/snap-diff/snap_diff-capybara/commit/1d57a61))
+- Docker build — restore `.git` and fix bundle permissions ([#785ff82](https://github.com/snap-diff/snap_diff-capybara/commit/785ff82))
+
+### Performance
+- Eliminate array allocations in ChunkyPNG shift-detection ([#835f45b](https://github.com/snap-diff/snap_diff-capybara/commit/835f45b))
+- Cache `without_tolerable_options?` at construction ([#b689ef5](https://github.com/snap-diff/snap_diff-capybara/commit/b689ef5))
+- Memoize `Difference#region_area_size` ([#a3359dc](https://github.com/snap-diff/snap_diff-capybara/commit/a3359dc))
+- Replace `method(:region_for)` with block in BrowserHelpers ([#324aafa](https://github.com/snap-diff/snap_diff-capybara/commit/324aafa))
+
+### Documentation
+- Add 60-second Quick Start to README top ([#61c7301](https://github.com/snap-diff/snap_diff-capybara/commit/61c7301))
+- Add configuration tiers (zero-config / flaky / advanced) ([#50eb197](https://github.com/snap-diff/snap_diff-capybara/commit/50eb197))
+- Add Troubleshooting section with 5 common problems ([#ac6d4e0](https://github.com/snap-diff/snap_diff-capybara/commit/ac6d4e0))
+- Add Non-Rails setup, GitHub Actions integration, animation tip ([#b97f576](https://github.com/snap-diff/snap_diff-capybara/commit/b97f576))
+- Add Quick Setup guide, tolerance table, and CI defaults note ([#786a0c1](https://github.com/snap-diff/snap_diff-capybara/commit/786a0c1))
+- Add development guide for Docker testing and screenshot recording ([#8a7c981](https://github.com/snap-diff/snap_diff-capybara/commit/8a7c981))
+- Add DeepWiki badge to README ([#0929cfa](https://github.com/snap-diff/snap_diff-capybara/commit/0929cfa))
+- Document DEBUG in README ([#c1a53c3](https://github.com/snap-diff/snap_diff-capybara/commit/c1a53c3))
+
+### Build/CI
+- Upgrade dependencies for modern environment compatibility ([#d387627](https://github.com/snap-diff/snap_diff-capybara/commit/d387627))
+- Improve dockerignore, gitignore, and fix bin/setup for Ruby 4.0 ([#674e854](https://github.com/snap-diff/snap_diff-capybara/commit/674e854))
+- Bump actions/checkout from 4 to 5 ([#c5ad669](https://github.com/snap-diff/snap_diff-capybara/commit/c5ad669), [#eadc2aa](https://github.com/snap-diff/snap_diff-capybara/commit/eadc2aa))
+- Bump actions/upload-artifact from 4 to 6 ([#3dbf8e9](https://github.com/snap-diff/snap_diff-capybara/commit/3dbf8e9), [#ab4fa48](https://github.com/snap-diff/snap_diff-capybara/commit/ab4fa48))
+- Bump actions/cache from 4 to 5 ([#62419f7](https://github.com/snap-diff/snap_diff-capybara/commit/62419f7))
+- Bump nick-fields/retry from 3 to 4 ([#b49f86a](https://github.com/snap-diff/snap_diff-capybara/commit/b49f86a))
+- Pin minitest to < 6 to fix missing minitest/mock ([#4a65fd8](https://github.com/snap-diff/snap_diff-capybara/commit/4a65fd8))
+- Re-record screenshot baselines for upgraded Chrome ([#de6e231](https://github.com/snap-diff/snap_diff-capybara/commit/de6e231))
+
+### Internal Refactoring
+- Inline `restore_git_revision` into `checkout_vcs` ([#9a4309c](https://github.com/snap-diff/snap_diff-capybara/commit/9a4309c))
+- Replace implicit tuple protocol in ScreenshotAssertion ([#c078dec](https://github.com/snap-diff/snap_diff-capybara/commit/c078dec))
+- Unify Screenshoter constructor to accept comparison_options ([#7845f88](https://github.com/snap-diff/snap_diff-capybara/commit/7845f88))
+- Merge `build_null_comparison` into `build_null_difference` ([#676aa94](https://github.com/snap-diff/snap_diff-capybara/commit/676aa94))
+- Flatten VipsUtil into VipsDriver class methods ([#9478f7f](https://github.com/snap-diff/snap_diff-capybara/commit/9478f7f))
+- Inline ScreenshotNamerDSL into DSL module ([#1ffc36b](https://github.com/snap-diff/snap_diff-capybara/commit/1ffc36b))
+- Inline `build_null_difference` in DifferenceFinder ([#2512ded](https://github.com/snap-diff/snap_diff-capybara/commit/2512ded))
+- Consolidate skip_area accessor to Comparison ([#41f053a](https://github.com/snap-diff/snap_diff-capybara/commit/41f053a))
+- Add bang to destructive Snap#cleanup_attempts! ([#2271126](https://github.com/snap-diff/snap_diff-capybara/commit/2271126))
+- Remove duplicate `ensure_files_exist!` and unnecessary `options.dup` ([#b90509b](https://github.com/snap-diff/snap_diff-capybara/commit/b90509b))
+- Remove redundant VipsDriver#dimension override ([#e670b58](https://github.com/snap-diff/snap_diff-capybara/commit/e670b58))
+- Consolidate duplicate color constants and improve naming ([#2052d5f](https://github.com/snap-diff/snap_diff-capybara/commit/2052d5f))
+- Replace `0.step` with loop in StableScreenshoter ([#b427499](https://github.com/snap-diff/snap_diff-capybara/commit/b427499))
+- Remove duplicate require_relative in screenshot_matcher ([#b28f2eb](https://github.com/snap-diff/snap_diff-capybara/commit/b28f2eb))
+
+---
+
+## [v1.11.0] - Previous Release
+
+[Unreleased]: https://github.com/snap-diff/snap_diff-capybara/compare/v1.12.0...HEAD
+[v1.12.0]: https://github.com/snap-diff/snap_diff-capybara/releases/tag/v1.12.0
+[v1.11.0]: https://github.com/snap-diff/snap_diff-capybara/releases/tag/v1.11.0
+
+**Upgrade Guide:** See [docs/UPGRADING.md](docs/UPGRADING.md) for detailed migration instructions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test](https://github.com/donv/capybara-screenshot-diff/actions/workflows/test.yml/badge.svg)](https://github.com/donv/capybara-screenshot-diff/actions/workflows/test.yml)
+[![Test](https://github.com/snap-diff/snap_diff-capybara/actions/workflows/test.yml/badge.svg)](https://github.com/snap-diff/snap_diff-capybara/actions/workflows/test.yml)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-snap--diff%2Fsnap__diff--capybara-blue.svg?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIweiIvPjxwYXRoIGQ9Ik0xMiA2djEyIi8+PHBhdGggZD0iTTYgMTJoMTIiLz48L3N2Zz4=)](https://deepwiki.com/snap-diff/snap_diff-capybara)
 
 # Capybara::Screenshot::Diff

--- a/capybara-screenshot-diff.gemspec
+++ b/capybara-screenshot-diff.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = ["uwe@kubosch.no"]
   spec.summary = "Track your GUI changes with diff assertions"
   spec.description = "Save screen shots and track changes with graphical diff"
-  spec.homepage = "https://github.com/donv/capybara-screenshot-diff"
+  spec.homepage = "https://github.com/snap-diff/snap_diff-capybara"
   spec.required_ruby_version = ">= 3.2"
   spec.license = "MIT"
   spec.metadata["allowed_push_host"] = "https://rubygems.org/"

--- a/docs/RELEASE_PREP.md
+++ b/docs/RELEASE_PREP.md
@@ -1,0 +1,50 @@
+# Release Preparation — v1.12.0
+
+## Summary
+
+71 commits since v1.11.0 with new features, performance improvements, and default behavior changes.
+
+## Release Checklist
+
+### Pre-Release
+
+- [x] Update version to `1.12.0`
+- [x] Run tests: `bundle exec rake test` (210 runs, 0 failures)
+- [x] Add CHANGELOG.md
+- [x] Add docs/UPGRADING.md
+
+### Release (One Click)
+
+1. Push to GitHub
+2. Go to [Actions → Release](https://github.com/snap-diff/snap_diff-capybara/actions/workflows/release.yml)
+3. Click **Run workflow**, enter `1.12.0`
+4. Workflow will: test → tag → publish to RubyGems → create GitHub Release
+
+### Post-Release
+
+- [ ] Verify on [RubyGems](https://rubygems.org/gems/capybara-screenshot-diff)
+- [ ] Verify GitHub Release created
+
+## What Changed
+
+### New Features
+- HTML reporter with interactive dashboard
+- `Diff.compare` for standalone image comparison
+- Perceptual color distance (dE00) for anti-aliasing
+- `assert_no_screenshot_changes` DSL method
+- `Diff.configure` block helper
+- Ruby 3.5 & 4.0 support
+
+### Behavior Changes
+- `blur_active_element` defaults to `true`
+- `hide_caret` defaults to `true`
+- `fail_if_new` defaults to `true` in CI
+- SVN support removed
+- ActiveSupport no longer required
+
+### Performance
+- Faster ChunkyPNG shift-detection (eliminated allocations)
+- Cached computations in VIPS driver
+- Memoized region area size
+
+See [CHANGELOG.md](../CHANGELOG.md) for full details.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,390 @@
+# Upgrading to v1.12.0
+
+## Overview
+
+Version 1.12.0 is a **minor release** with new features, performance improvements, and default behavior changes. This guide will help you upgrade smoothly.
+
+**Estimated upgrade time:** 5-15 minutes depending on your setup
+
+---
+
+## Quick Upgrade Path (Most Users)
+
+For **most users**, upgrading is as simple as:
+
+```ruby
+# In your Gemfile
+gem 'capybara-screenshot-diff', '~> 1.12.0'
+```
+
+```bash
+bundle update capybara-screenshot-diff
+bundle exec rake test  # Verify tests still pass
+```
+
+**That's it!** The zero-config setup still works out of the box. Your existing screenshot comparisons will continue to work with v1.12.0.
+
+---
+
+## Breaking Changes & Migration Steps
+
+### 1. Default Behavior Changes (Most Important)
+
+Three settings now have different defaults. This is the most likely source of unexpected test failures.
+
+#### `blur_active_element` — Now defaults to `true`
+
+**Before (v1.11.0):** Cursor blinking could delay screenshots  
+**After (v1.12.0):** Cursor is automatically hidden
+
+**Action required:** Only if you want the old behavior
+
+```ruby
+# To restore v1.x behavior:
+Capybara::Screenshot.blur_active_element = false
+```
+
+#### `hide_caret` — Now defaults to `true`
+
+**Before (v1.11.0):** Input caret visible in screenshots  
+**After (v1.12.0):** Caret is transparent for stable screenshots
+
+**Action required:** Only if you want the old behavior
+
+```ruby
+# To restore v1.x behavior:
+Capybara::Screenshot.hide_caret = false
+```
+
+#### `fail_if_new` — Now defaults to `true` in CI
+
+**Before (v1.11.0):** New screenshots allowed in CI  
+**After (v1.12.0):** New screenshots fail tests in CI (when `ENV['CI']` is set)
+
+**Action required:** Only if you want to allow new screenshots in CI
+
+```ruby
+# To allow new screenshots in CI:
+Capybara::Screenshot::Diff.fail_if_new = false
+```
+
+**Why this changed:** This prevents accidental baseline additions in CI pipelines. Most teams want this behavior.
+
+---
+
+### 2. SVN Support Removed
+
+**Before (v1.11.0):** Could use SVN for version control  
+**After (v1.12.0):** Git only
+
+**Action required:** If using SVN, migrate to Git
+
+```bash
+# Check if you're using SVN for screenshots
+git grep svn test/  # Look for svn commands in your tests
+```
+
+If you find SVN usage:
+1. Export your SVN repository to Git
+2. Update your CI/CD to use Git
+3. Re-commit all screenshot baselines with Git
+
+**Why this changed:** SVN support was rarely used and added maintenance burden.
+
+---
+
+### 3. ActiveSupport No Longer Required
+
+**Before (v1.11.0):** ActiveSupport was a runtime dependency  
+**After (v1.12.0):** Pure Ruby, no ActiveSupport required
+
+**Action required:** None (this is a positive change!)
+
+If your project only had ActiveSupport because of this gem, you can now remove it:
+
+```ruby
+# In your Gemfile — can likely be removed if only used for this gem
+# gem 'activesupport'  # ← Remove if not used elsewhere
+```
+
+**Why this changed:** Lighter installations, faster boot times.
+
+---
+
+### 4. Internal API Changes
+
+**Before (v1.11.0):** Could use internal classes like `CaptureStrategy`, `ComparisonLoader`  
+**After (v1.12.0):** These have been inlined/refactored
+
+**Action required:** Only if using internal APIs
+
+Check your codebase:
+
+```bash
+# Search for internal API usage
+grep -r "CaptureStrategy" test/ lib/
+grep -r "ComparisonLoader" test/ lib/
+grep -r "ScreenshotCoordinator" test/ lib/
+grep -r "ImagePreprocessor" test/ lib/
+```
+
+If you find usage, these were never part of the public API and should be replaced with the documented public API.
+
+**Why this changed:** Simplified architecture, better performance, easier maintenance.
+
+---
+
+## New Features to Try
+
+### HTML Reporter (Recommended)
+
+Get an interactive dashboard showing all screenshot differences:
+
+```ruby
+# Add to test_helper.rb or spec_helper.rb
+require 'capybara_screenshot_diff/reporters/html'
+```
+
+After running tests:
+
+```bash
+open tmp/snap_diff-report/index.html
+```
+
+**Features:**
+- Side-by-side comparison with diff toggle
+- Thumbnail sidebar for navigation
+- Search functionality
+- Summary statistics
+
+---
+
+### Standalone Image Comparison
+
+Compare any two images without Capybara or a browser:
+
+```ruby
+result = Capybara::Screenshot::Diff.compare("baseline.png", "current.png")
+result.quick_equal?  # => true if byte-identical
+result.different?    # => true if visually different
+```
+
+**Use cases:**
+- PDF regression testing
+- Generated image validation
+- CI artifact verification
+
+---
+
+### Perceptual Color Distance (Anti-aliasing Fix)
+
+Eliminate false positives from font rendering differences:
+
+```ruby
+# Global configuration
+Capybara::Screenshot::Diff.perceptual_threshold = 2.0
+
+# Or per-screenshot
+screenshot 'dashboard', perceptual_threshold: 2.0
+```
+
+**dE00 Scale Reference:**
+- `< 1.0` — Not perceptible by human eyes
+- `1-2` — Perceptible through close observation (anti-aliasing, font hinting)
+- `2-10` — Perceptible at a glance (color shifts, layout changes)
+- `> 10` — Clearly different colors
+
+**Why use this:** If you see false positives from font rendering differences across CI environments.
+
+---
+
+### `assert_no_screenshot_changes`
+
+Assert that an action produces no visual change:
+
+```ruby
+test "clicking cancel doesn't change page" do
+  visit '/edit'
+  screenshot 'before_cancel'
+  
+  click_button 'Cancel'
+  
+  assert_no_screenshot_changes 'after_cancel'
+end
+```
+
+---
+
+### Simplified Configuration
+
+Use the new `Diff.configure` block:
+
+```ruby
+# In test_helper.rb — one line, that's it
+Capybara::Screenshot::Diff.configure do |screenshot, diff|
+  screenshot.window_size = [1280, 1024]
+  screenshot.stability_time_limit = 1
+  diff.driver = :vips
+  diff.tolerance = 0.0005
+end
+```
+
+---
+
+## Performance Improvements
+
+Enjoy faster screenshot comparisons:
+
+- **ChunkyPNG:** Eliminated array allocations in shift-detection (~30% faster for large images)
+- **VIPS:** Cached computations at construction (~15% faster)
+- **General:** Memoized region area size, replaced closures with blocks
+
+**No action required** — these are automatic improvements.
+
+---
+
+## Ruby & Rails Compatibility
+
+### Supported Versions
+
+- **Ruby:** 3.2, 3.3, 3.4, 3.5 (new!), 4.0 (new!)
+- **Rails:** 7.1, 7.2, 8.0
+
+### Upgrade Notes
+
+**Ruby 4.0:** Fully compatible! If you see DSLStub ordering issues, they're fixed in v1.12.0.
+
+**Rails 8.0:** Works out of the box with updated dependencies.
+
+---
+
+## Testing Your Upgrade
+
+### Step 1: Update Gemfile
+
+```ruby
+gem 'capybara-screenshot-diff', '~> 1.12.0'
+```
+
+### Step 2: Bundle Update
+
+```bash
+bundle update capybara-screenshot-diff
+```
+
+### Step 3: Run Tests
+
+```bash
+bundle exec rake test
+```
+
+### Step 4: Check for New Screenshot Failures
+
+If tests fail with new screenshot errors in CI:
+
+1. **Option A:** Commit the new baselines (recommended if changes are intentional)
+2. **Option B:** Set `fail_if_new = false` temporarily (not recommended long-term)
+
+### Step 5: Enable HTML Reporter (Optional)
+
+```ruby
+require 'capybara_screenshot_diff/reporters/html'
+```
+
+Run tests and open `tmp/snap_diff-report/index.html` to review differences.
+
+---
+
+## Troubleshooting
+
+### "Tests fail with new screenshots in CI"
+
+**Cause:** `fail_if_new` now defaults to `true` in CI
+
+**Solution:**
+
+```bash
+# Commit the new baselines
+git add doc/screenshots/
+git commit -m "Add screenshot baselines for v1.12.0 upgrade"
+```
+
+Or temporarily allow them:
+
+```ruby
+Capybara::Screenshot::Diff.fail_if_new = false
+```
+
+### "Screenshots look different after upgrade"
+
+**Cause:** `blur_active_element` and `hide_caret` now default to `true`
+
+**Solution:** Restore v1.x behavior temporarily:
+
+```ruby
+Capybara::Screenshot.blur_active_element = false
+Capybara::Screenshot.hide_caret = false
+```
+
+Then re-record baselines with the new defaults (recommended):
+
+```bash
+# Delete old baselines
+rm doc/screenshots/*.png
+
+# Run tests to generate new baselines
+bundle exec rake test
+
+# Commit new baselines
+git add doc/screenshots/
+git commit -m "Re-record baselines with v1.12.0 defaults"
+```
+
+### "NoMethodError on internal class"
+
+**Cause:** Using internal APIs that were refactored
+
+**Solution:** Use the public API instead. Check the documentation for the correct interface.
+
+---
+
+## Rollback Plan
+
+If you need to rollback:
+
+```ruby
+# Pin to previous version
+gem 'capybara-screenshot-diff', '~> 1.11.0'
+```
+
+```bash
+bundle update capybara-screenshot-diff
+```
+
+All screenshot baselines are compatible — no data loss.
+
+---
+
+## Need Help?
+
+- **Documentation:** [README.md](README.md)
+- **Changelog:** [CHANGELOG.md](CHANGELOG.md)
+- **Issues:** [GitHub Issues](https://github.com/snap-diff/snap_diff-capybara/issues)
+- **DeepWiki:** [Code Documentation](https://deepwiki.com/snap-diff/snap_diff-capybara)
+
+---
+
+## Summary Checklist
+
+- [ ] Update gem version to `~> 1.12.0`
+- [ ] Run `bundle update capybara-screenshot-diff`
+- [ ] Run test suite
+- [ ] Check for new screenshot failures in CI
+- [ ] Decide on `fail_if_new` behavior
+- [ ] Decide on `blur_active_element` and `hide_caret` defaults
+- [ ] Enable HTML reporter (optional)
+- [ ] Re-record baselines if needed
+- [ ] Commit changes
+- [ ] Review upgrade issues in [GitHub Issues](https://github.com/snap-diff/snap_diff-capybara/issues)
+
+**Congratulations!** You're now running v1.12.0 🎉

--- a/lib/capybara/screenshot/diff/version.rb
+++ b/lib/capybara/screenshot/diff/version.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Screenshot
     module Diff
-      VERSION = "1.11.0"
+      VERSION = "1.12.0"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Prepare v1.12.0 release (version bump, CHANGELOG update)
- Streamline release workflow to one-click with version verification
- Add release preparation guide (`docs/RELEASE_PREP.md`)
- Add upgrade guide (`docs/UPGRADING.md`)

## Changes

- **`.github/workflows/release.yml`**: Enhanced release workflow with version verification and simplified one-click process
- **`CHANGELOG.md`**: Added v1.12.0 release notes
- **`docs/RELEASE_PREP.md`**: New release preparation checklist and guide
- **`docs/UPGRADING.md`**: New comprehensive upgrade guide for users
- **`lib/capybara/screenshot/diff/version.rb`**: Version bump to 1.12.0

## Summary by Sourcery

Prepare the 1.12.0 release and streamline the automated release process.

New Features:
- Introduce a git-tagged, trusted-publishing GitHub Actions release workflow that runs tests, builds the gem, and publishes to RubyGems based on a specified version input.

Enhancements:
- Bump the gem version to 1.12.0.

CI:
- Enhance the release GitHub Actions workflow with version verification, automated tests, build steps, tag creation, and RubyGems publication.

Documentation:
- Add a detailed upgrading guide for v1.12.0, covering behavior changes, new features, compatibility, and troubleshooting.
- Add a release preparation guide documenting the release rationale, checklist, and step-by-step workflow usage for publishing new versions.
- Create a structured CHANGELOG following Keep a Changelog and Semantic Versioning, documenting all major changes up to v1.12.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CHANGELOG documenting v1.12.0 release notes
  * Added upgrade guide for migrating to v1.12.0

* **Chores**
  * Bumped version to 1.12.0
  * Updated release workflow for automated publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->