### PR TITLE
fix: clean up reporter diff artifacts on Snap#delete!

### DIFF
--- a/lib/capybara/screenshot/diff/reporters/default.rb
+++ b/lib/capybara/screenshot/diff/reporters/default.rb
@@ -33,6 +33,7 @@ module Capybara::Screenshot::Diff
       def clean_tmp_files
         annotated_base_image_path.unlink if annotated_base_image_path.exist?
         annotated_image_path.unlink if annotated_image_path.exist?
+        heatmap_diff_path.unlink if heatmap_diff_path.exist?
       end
 
       def build_error_for_different_dimensions

--- a/lib/capybara_screenshot_diff/snap.rb
+++ b/lib/capybara_screenshot_diff/snap.rb
@@ -60,7 +60,7 @@ module CapybaraScreenshotDiff
         path.sub_ext(".diff.#{format}"),
         path.sub_ext(".heatmap.diff.#{format}"),
         base_path.sub_ext(".diff.#{format}")
-      ].each { |f| f.delete if f.exist? }
+      ].each { |f| f.unlink if f.exist? }
     end
   end
 end

--- a/lib/capybara_screenshot_diff/snap.rb
+++ b/lib/capybara_screenshot_diff/snap.rb
@@ -16,6 +16,7 @@ module CapybaraScreenshotDiff
     def delete!
       path.delete if path.exist?
       base_path.delete if base_path.exist?
+      cleanup_diff_artifacts!
       cleanup_attempts!
     end
 
@@ -50,6 +51,16 @@ module CapybaraScreenshotDiff
 
     def find_attempts_paths
       Dir[@manager.abs_path_for("**/#{full_name}.attempt_[0-9][0-9].#{format}")]
+    end
+
+    private
+
+    def cleanup_diff_artifacts!
+      [
+        path.sub_ext(".diff.#{format}"),
+        path.sub_ext(".heatmap.diff.#{format}"),
+        base_path.sub_ext(".diff.#{format}")
+      ].each { |f| f.delete if f.exist? }
     end
   end
 end

--- a/test/unit/reporters/default_test.rb
+++ b/test/unit/reporters/default_test.rb
@@ -30,6 +30,22 @@ module Capybara::Screenshot::Diff
       assert_same_images "a-and-b.heatmap.diff.png", reporter.heatmap_diff_path
     end
 
+    test "#clean_tmp_files removes heatmap diff along with other diff artifacts" do
+      skip "VIPS not present. Skipping VIPS driver tests." unless defined?(Vips)
+      driver = Drivers::VipsDriver.new
+      comparison = build_comparison_for(driver, "a.png", "b.png")
+      reporter = Reporters::Default.new(driver.find_difference_region(comparison))
+      reporter.generate
+
+      assert_predicate reporter.heatmap_diff_path, :exist?
+
+      reporter.clean_tmp_files
+
+      assert_not reporter.annotated_image_path.exist?, "diff should be cleaned"
+      assert_not reporter.annotated_base_image_path.exist?, "base diff should be cleaned"
+      assert_not reporter.heatmap_diff_path.exist?, "heatmap diff should be cleaned"
+    end
+
     private
 
     def build_comparison_for(driver, *images)

--- a/test/unit/snap_manager_test.rb
+++ b/test/unit/snap_manager_test.rb
@@ -67,7 +67,6 @@ module CapybaraScreenshotDiff
       @manager.provision_snap_with(snap, source)
       @manager.provision_snap_with(snap, source, version: :base)
 
-      # Simulate reporter artifacts
       diff_path = snap.path.sub_ext(".diff.png")
       base_diff_path = snap.path.sub_ext(".base.diff.png")
       heatmap_path = snap.path.sub_ext(".heatmap.diff.png")

--- a/test/unit/snap_manager_test.rb
+++ b/test/unit/snap_manager_test.rb
@@ -60,5 +60,24 @@ module CapybaraScreenshotDiff
       assert_includes snap.base_path.to_s, "test_image.base.png"
       assert_includes snap.next_attempt_path!.to_s, "test_image.attempt_00.png"
     end
+
+    test "#cleanup! removes diff artifacts created by reporters" do
+      snap = @manager.snapshot("test_image")
+      source = fixture_image_path_from("a")
+      @manager.provision_snap_with(snap, source)
+      @manager.provision_snap_with(snap, source, version: :base)
+
+      # Simulate reporter artifacts
+      diff_path = snap.path.sub_ext(".diff.png")
+      base_diff_path = snap.path.sub_ext(".base.diff.png")
+      heatmap_path = snap.path.sub_ext(".heatmap.diff.png")
+      [diff_path, base_diff_path, heatmap_path].each { |p| FileUtils.cp(source, p) }
+
+      @manager.cleanup!
+
+      assert_not diff_path.exist?, "diff artifact should be cleaned up"
+      assert_not base_diff_path.exist?, "base diff artifact should be cleaned up"
+      assert_not heatmap_path.exist?, "heatmap diff artifact should be cleaned up"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **`Snap#delete!`** now removes `.diff.png`, `.base.diff.png`, and `.heatmap.diff.png` artifacts created by `Reporters::Default` — previously these were orphaned on every test run
- **`Reporters::Default#clean_tmp_files`** now also removes `.heatmap.diff.png` (was missing)
- Reduces `tmp/` bloat from ~30 leaked files per test run (accumulating indefinitely) to 0

## Context

Each unit test run left reporter diff artifacts behind because:
1. `Snap#delete!` only cleaned `.png` and `.base.png` but not the 3 reporter-generated diff files
2. `Reporters::Default#clean_tmp_files` cleaned 2 of 3 artifact types (missed heatmap)
3. Test names include `Time.now.nsec`, so old artifacts never matched for cleanup

## Test plan

- [x] Added test: `SnapManagerTest#cleanup! removes diff artifacts created by reporters`
- [x] Added test: `DefaultTest#clean_tmp_files removes heatmap diff along with other diff artifacts`
- [x] Verified: `tmp/` stays at 2-3 files across multiple runs (was 31→56→80+)
- [x] Verified: `DEBUG` / `persist_comparisons?` escape hatch still works
- [x] Full test suite passes (181 tests, 587 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure snapshot deletion and reporter cleanup remove all generated diff artifacts to prevent tmp directory bloat.

Bug Fixes:
- Remove reporter-generated diff artifacts when deleting snaps to avoid leaving orphaned files in tmp.
- Include heatmap diff images in the default reporter temporary file cleanup so all diff variants are removed.

Tests:
- Add coverage to verify SnapManager.cleanup! removes reporter diff artifacts for snaps.
- Add test to confirm Reporters::Default#clean_tmp_files deletes heatmap diff images alongside other diff artifacts.