### PR TITLE
docs: test fixtures README and ADR-006 cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,8 +35,18 @@ task "report:sample", [:embed] do |_t, args|
   ruby "scripts/generate_sample_report.rb #{embed_arg}"
 end
 
+desc "Remove screenshot diff artifacts (keeps baselines)"
+task "snap_diff:clean" do
+  patterns = ["**/*.diff.png", "**/*.base.diff.png", "**/*.heatmap.diff.png",
+    "**/*.diff.webp", "**/*.base.diff.webp", "**/*.heatmap.diff.webp",
+    "**/snap_diff_report.html"]
+  removed = patterns.flat_map { |p| Dir.glob("tmp/#{p}") + Dir.glob("doc/screenshots/#{p}") }
+  removed.each { |f| FileUtils.rm_f(f) }
+  puts "Removed #{removed.size} diff artifacts"
+end
+
 task "clobber" do
-  puts "Cleanup tmp/*.png"
+  puts "Cleanup tmp/"
   FileUtils.rm_rf(Dir["./tmp/*"])
 end
 

--- a/test/fixtures/images/README.md
+++ b/test/fixtures/images/README.md
@@ -1,0 +1,24 @@
+# Test Fixture Images
+
+These images are used by the unit test suite for image comparison testing.
+
+| File | Description |
+|------|-------------|
+| `a.png` | Base island map (80x80) |
+| `b.png` | Modified island map — small region differs from `a.png` |
+| `c.png` | Modified island map — different region differs from `a.png` |
+| `d.png` | Modified island map — another variation |
+| `a_cropped.png` | Cropped version of `a.png` |
+| `portrait.png` | Portrait orientation image (3x6) |
+| `portrait_b.png` | Modified portrait — differs from `portrait.png` |
+| `a.webp` | WebP version of `a.png` |
+
+## Generated artifacts (gitignored)
+
+These files are generated during test runs and should NOT be committed:
+
+| Pattern | Description |
+|---------|-------------|
+| `*.diff.png` | Annotated diff overlay |
+| `*.base.diff.png` | Annotated base image |
+| `*.heatmap.diff.png` | Heatmap of pixel differences |


### PR DESCRIPTION
## Summary

- T2: Add test/fixtures/images/README.md documenting fixture images
- T3: Investigated — nested test classes already inherit parent setup, no duplication
- T4: Investigated — assertion helpers serve different contexts, not duplicated  
- T6: Investigated — param order follows Minitest convention, not a bug

ADR-006 test simplification is now complete (T1-T8 all resolved across PRs #174 and this one).

## Test plan
- [x] All tests pass (218 runs, 651 assertions)

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add README describing image fixture files and their purposes, including notes on generated diff artifacts that are gitignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing test image fixtures for visual-comparison tests, listing expected fixture variants and the generated diff artifact patterns (not to be committed).

* **Chores**
  * Added a cleanup routine to find and remove generated screenshot/diff artifacts and updated the general cleanup behavior and console messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->