### PR TITLE
fix: deduplicate glob results in snap_diff:clean

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ task "snap_diff:clean" do
   patterns = ["**/*.diff.png", "**/*.base.diff.png", "**/*.heatmap.diff.png",
     "**/*.diff.webp", "**/*.base.diff.webp", "**/*.heatmap.diff.webp",
     "**/snap_diff_report.html"]
-  removed = patterns.flat_map { |p| Dir.glob("tmp/#{p}") + Dir.glob("doc/screenshots/#{p}") }
+  removed = patterns.flat_map { |p| Dir.glob("tmp/#{p}") + Dir.glob("doc/screenshots/#{p}") }.uniq
   removed.each { |f| FileUtils.rm_f(f) }
   puts "Removed #{removed.size} diff artifacts"
 end


### PR DESCRIPTION
## Summary
- Add `.uniq` to glob results in `snap_diff:clean` rake task to prevent over-counting when overlapping patterns (`*.diff.png` matches `*.base.diff.png` and `*.heatmap.diff.png`) produce duplicate paths

## Context
Found via CodeRabbit review on #177

## Test plan
- [ ] `rake snap_diff:clean` reports accurate count
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure snap_diff:clean reports an accurate count of removed diff artifacts when glob patterns overlap.