### PR TITLE
feat: always print summary after tests (like SimpleCov)

### DIFF
--- a/lib/capybara_screenshot_diff/reporters/html.rb
+++ b/lib/capybara_screenshot_diff/reporters/html.rb
@@ -68,6 +68,19 @@ module CapybaraScreenshotDiff
         (passed.to_f / total * 100).round(1)
       end
 
+      def summary
+        return if total.zero?
+
+        screenshots_label = (total == 1) ? "1 screenshot" : "#{total} screenshots"
+
+        if failures.empty?
+          "[snap_diff] #{screenshots_label} compared, no failures."
+        else
+          failures_label = (failures.size == 1) ? "1 failure" : "#{failures.size} failures"
+          "[snap_diff] #{screenshots_label} compared, #{failures_label}. Report: #{output_path}"
+        end
+      end
+
       def render
         ERB.new(File.read(self.class.template_path)).result(binding)
       end
@@ -130,8 +143,8 @@ end
 
 at_exit do
   CapybaraScreenshotDiff.reporters_mutex.synchronize { CapybaraScreenshotDiff.reporters.dup }.each do |reporter|
-    result = reporter.finalize
-    $stdout.puts "[snap_diff] HTML report: #{result}" if result.is_a?(Pathname)
+    reporter.finalize
+    $stdout.puts reporter.summary if reporter.respond_to?(:summary) && reporter.summary
   rescue => e
     warn "[snap_diff] Reporter #{reporter.class} failed (#{e.class}: #{e.message})" if ENV["DEBUG"]
   end

--- a/lib/capybara_screenshot_diff/reporters/html.rb
+++ b/lib/capybara_screenshot_diff/reporters/html.rb
@@ -63,11 +63,6 @@ module CapybaraScreenshotDiff
       def passed = total - failures.size
       def failed = failures.size
 
-      def success_rate
-        return 0 if total.zero?
-        (passed.to_f / total * 100).round(1)
-      end
-
       def summary
         return if total.zero?
 
@@ -144,8 +139,10 @@ end
 at_exit do
   CapybaraScreenshotDiff.reporters_mutex.synchronize { CapybaraScreenshotDiff.reporters.dup }.each do |reporter|
     reporter.finalize
-    $stdout.puts reporter.summary if reporter.respond_to?(:summary) && reporter.summary
+    if (msg = reporter.summary)
+      $stdout.puts msg
+    end
   rescue => e
-    warn "[snap_diff] Reporter #{reporter.class} failed (#{e.class}: #{e.message})" if ENV["DEBUG"]
+    warn "[snap_diff] Reporter #{reporter.class} failed (#{e.class}: #{e.message})"
   end
 end

--- a/test/unit/reporters/html_reporter_test.rb
+++ b/test/unit/reporters/html_reporter_test.rb
@@ -195,7 +195,7 @@ module CapybaraScreenshotDiff
         summary = reporter.summary
         assert_includes summary, "1 screenshot"
         assert_includes summary, "no failures"
-        refute_includes summary, "report"
+        refute_includes summary, @output_path.to_s
       end
 
       test "#summary when no screenshots recorded" do

--- a/test/unit/reporters/html_reporter_test.rb
+++ b/test/unit/reporters/html_reporter_test.rb
@@ -173,6 +173,20 @@ module CapybaraScreenshotDiff
         assert_includes summary, @output_path.to_s
       end
 
+      test "#summary pluralizes failures label for multiple failures" do
+        reporter = HTML.new(output_path: @output_path)
+        reporter.record([
+          build_failing_assertion("first failure"),
+          build_failing_assertion("second failure")
+        ])
+        reporter.finalize
+
+        summary = reporter.summary
+        assert_includes summary, "2 failures"
+        assert_includes summary, "2 screenshots"
+        assert_includes summary, @output_path.to_s
+      end
+
       test "#summary when all pass shows no failures" do
         reporter = HTML.new(output_path: @output_path)
         reporter.record([build_passing_assertion("ok")])

--- a/test/unit/reporters/html_reporter_test.rb
+++ b/test/unit/reporters/html_reporter_test.rb
@@ -146,6 +146,49 @@ module CapybaraScreenshotDiff
         assert_operator fake_mutex.synchronize_calls, :>=, 1
       end
 
+      test "#finalize returns output_path when there are failures" do
+        reporter = HTML.new(output_path: @output_path)
+        reporter.record([build_failing_assertion("fail")])
+        result = reporter.finalize
+
+        assert_instance_of Pathname, result
+      end
+
+      test "#finalize returns nil when no failures" do
+        reporter = HTML.new(output_path: @output_path)
+        reporter.record([build_passing_assertion("pass")])
+        result = reporter.finalize
+
+        assert_nil result
+      end
+
+      test "#summary returns screenshot count and status" do
+        reporter = HTML.new(output_path: @output_path)
+        reporter.record([build_passing_assertion("ok"), build_failing_assertion("fail")])
+        reporter.finalize
+
+        summary = reporter.summary
+        assert_includes summary, "1 failure"
+        assert_includes summary, "2 screenshots"
+        assert_includes summary, @output_path.to_s
+      end
+
+      test "#summary when all pass shows no failures" do
+        reporter = HTML.new(output_path: @output_path)
+        reporter.record([build_passing_assertion("ok")])
+        reporter.finalize
+
+        summary = reporter.summary
+        assert_includes summary, "1 screenshot"
+        assert_includes summary, "no failures"
+        refute_includes summary, "report"
+      end
+
+      test "#summary when no screenshots recorded" do
+        reporter = HTML.new(output_path: @output_path)
+        assert_nil reporter.summary
+      end
+
       test "#finalize can retry after write_report failure" do
         reporter = HTML.new(output_path: @output_path)
         reporter.record([build_failing_assertion("retry")])


### PR DESCRIPTION
## Summary
- Add `#summary` method to HTML reporter that prints after every test run
- Follows SimpleCov pattern: always show status so devs know reporter is active

## Output examples
```
[snap_diff] 47 screenshots compared, 2 failures. Report: doc/screenshots/snap_diff_report.html
[snap_diff] 47 screenshots compared, no failures.
```

When no screenshots are taken (reporter not used or disabled), nothing prints.

## Context
In jetthoughts.github.io, after upgrading to v1.12.0 with the HTML reporter enabled, there was no visible output confirming the reporter was working. SimpleCov always prints `Coverage report generated for ... to coverage/index.html` regardless of pass/fail.

## Test plan
- [x] 5 new tests for summary output (failures, pass, empty)
- [x] 223 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a summary output for the HTML reporter that always prints a concise test run status at exit.

New Features:
- Introduce an HTML reporter summary method that reports screenshot counts, failure status, and report path.
- Print a standardized snap_diff summary line after each run when the reporter is used.

Tests:
- Add unit tests covering HTML reporter finalize return values and summary output for failing, passing, and empty runs.