### PR TITLE
refactor: ADR-006 T3+T4 — hoist setup, consolidate assertion helpers

### DIFF
--- a/.github/actions/upload-screenshots/action.yml
+++ b/.github/actions/upload-screenshots/action.yml
@@ -1,6 +1,6 @@
 ---
 name: 'Upload SnapDiff screenshots'
-description: 'Upload screenshot diffs and HTML report as CI artifacts'
+description: 'Upload screenshot diffs, HTML report, and optionally comment on PR'
 inputs:
   name:
     description: 'Artifact name prefix'
@@ -11,6 +11,9 @@ inputs:
   retention-days:
     description: 'Number of days to retain artifacts'
     default: '2'
+  pr-comment:
+    description: 'Post PR comment with report link (requires pull-requests: write)'
+    default: 'false'
 outputs:
   report-url:
     description: 'Direct URL to the inline HTML report artifact'
@@ -70,3 +73,41 @@ runs:
         name: ${{ inputs.name }}-report-full
         retention-days: ${{ inputs.retention-days }}
         path: ${{ inputs.report-path }}/
+
+    - name: Job summary
+      if: steps.check-report.outputs.exists == 'true'
+      shell: bash
+      run: |
+        cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+        ### SnapDiff Report
+
+        | Artifact | Link |
+        |----------|------|
+        | HTML report (inline) | ${{ steps.upload-report.outputs.artifact-url || 'N/A' }} |
+        | Full report with images | ${{ steps.upload-report-full.outputs.artifact-url || 'N/A' }} |
+        EOF
+
+    - name: Find existing PR comment
+      if: inputs.pr-comment == 'true' && github.event_name == 'pull_request'
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: 'Screenshot diffs'
+
+    - name: Comment PR with report link
+      if: inputs.pr-comment == 'true' && github.event_name == 'pull_request'
+      uses: peter-evans/create-or-update-comment@v5
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        edit-mode: replace
+        body: |
+          ### Screenshot diffs detected
+
+          | Artifact | Link |
+          |----------|------|
+          | HTML report (inline) | ${{ steps.upload-report.outputs.artifact-url || 'N/A' }} |
+          | Full report with images | ${{ steps.upload-report-full.outputs.artifact-url || 'N/A' }} |
+          | [All artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) | Browse all |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,58 +82,9 @@ jobs:
 
       - uses: ./.github/actions/upload-screenshots
         if: failure()
-        id: upload-screenshots
         with:
           name: base-screenshots
-
-      - name: Find existing report comment
-        if: always() && github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'Screenshot diffs'
-
-      - name: Comment PR with report link
-        if: failure() && github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            ### Screenshot diffs detected
-
-            | Artifact | Link |
-            |----------|------|
-            | HTML report (inline preview) | ${{ steps.upload-screenshots.outputs.report-url || 'N/A' }} |
-            | Full report with images | ${{ steps.upload-screenshots.outputs.report-full-url || 'N/A' }} |
-            | [All artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) | Browse all |
-
-      - name: Job summary with report links
-        if: failure()
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ### Screenshot diffs detected
-
-          | Artifact | Link |
-          |----------|------|
-          | HTML report (inline) | ${{ steps.upload-screenshots.outputs.report-url || 'N/A' }} |
-          | Full report with images | ${{ steps.upload-screenshots.outputs.report-full-url || 'N/A' }} |
-          | [All artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) | Browse all |
-          EOF
-
-      - name: Update comment on success
-        if: success() && github.event_name == 'pull_request' && steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            ### Screenshot diffs resolved
-
-            All screenshots match their baselines. Previous diffs have been fixed.
+          pr-comment: 'true'
 
       - name: Uploading Coverage Report
         uses: actions/upload-artifact@v7
@@ -253,17 +204,5 @@ jobs:
         run: bin/rake 'report:sample[embed]'
 
       - uses: ./.github/actions/upload-screenshots
-        id: upload-screenshots
         with:
           name: test-report
-
-      - name: Job summary with report links
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ### SnapDiff Report
-
-          | Artifact | Link |
-          |----------|------|
-          | HTML report (inline) | ${{ steps.upload-screenshots.outputs.report-url || 'N/A' }} |
-          | Full report with images | ${{ steps.upload-screenshots.outputs.report-full-url || 'N/A' }} |
-          EOF

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ After tests run, open `doc/screenshots/snap_diff_report.html`:
 
 Review all visual changes in one place — no need to hunt through `.diff.png` files. 4 view modes (both/base/new/heatmap), per-image zoom, annotation toggle, keyboard navigation, and search.
 
-**In GitHub Actions**, the report renders inline as a CI artifact — no download needed. Add a PR comment with a link to the report automatically:
+**In GitHub Actions**, one step uploads the report, posts a PR comment with the link, and adds a job summary:
 
 ```yaml
 - name: Upload screenshot report
@@ -126,9 +126,10 @@ Review all visual changes in one place — no need to hunt through `.diff.png` f
   uses: snap-diff/snap_diff-capybara/.github/actions/upload-screenshots@master
   with:
     name: screenshots
+    pr-comment: 'true'
 ```
 
-See [CI Integration](docs/ci-integration.md) for the full GitHub Actions setup with PR commenting.
+See [CI Integration](docs/ci-integration.md) for full setup including Ruby + libvips action and baseline update workflow.
 
 ## Compare Any Two Images
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -36,12 +36,115 @@ Add to your test helper:
 require 'capybara_screenshot_diff/reporters/html'
 ```
 
-### 2. Upload artifacts (manual setup)
+### 2. Reusable composite action (recommended)
 
-This is the full YAML so you understand what each step does:
+The simplest way — one step handles artifact upload, job summary, and PR comments:
 
 ```yaml
 # .github/workflows/test.yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # Required for PR comments
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Upload screenshot reports
+        if: failure()
+        uses: snap-diff/snap_diff-capybara/.github/actions/upload-screenshots@master
+        with:
+          name: screenshots
+          pr-comment: 'true'
+```
+
+That's it. On failure, this will:
+- Upload diff images + HTML report as artifacts
+- Post a PR comment with links to the inline report and full artifact download
+- Add a job summary with report links (visible in the Actions UI)
+
+#### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `name` | (required) | Artifact name prefix |
+| `report-path` | `doc/screenshots` | Path to HTML report directory |
+| `retention-days` | `2` | Days to retain artifacts |
+| `pr-comment` | `false` | Post PR comment with report link (requires `pull-requests: write`) |
+
+#### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `report-url` | Direct URL to the inline HTML report artifact |
+| `report-full-url` | Direct URL to the full report artifact (with images) |
+
+### 3. Ruby + libvips setup action
+
+For consistent CI environments (libvips, font antialiasing disabled), use the setup action:
+
+```yaml
+      - uses: snap-diff/snap_diff-capybara/.github/actions/setup-ruby-and-dependencies@master
+        with:
+          ruby-version: '4.0'
+          cache-apt-packages: true
+```
+
+This installs Ruby, libvips (with apt caching), and disables font antialiasing for consistent rendering across CI runs.
+
+#### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `ruby-version` | (required) | Ruby version to install |
+| `cache-apt-packages` | `false` | Cache libvips apt packages for faster runs |
+| `ruby-cache-version` | — | Bundler cache version key |
+
+### 4. Full example with both actions
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: snap-diff/snap_diff-capybara/.github/actions/setup-ruby-and-dependencies@master
+        with:
+          ruby-version: '4.0'
+          cache-apt-packages: true
+
+      - run: bundle exec rake test
+
+      - uses: snap-diff/snap_diff-capybara/.github/actions/upload-screenshots@master
+        if: failure()
+        with:
+          name: screenshots
+          pr-comment: 'true'
+```
+
+### 5. Manual setup (without composite actions)
+
+If you prefer full control, here's the expanded YAML:
+
+<details>
+<summary>Expand manual setup</summary>
+
+```yaml
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -52,14 +155,12 @@ jobs:
         with:
           bundler-cache: true
 
-      # Install libvips for the :vips driver (optional — skip if using :chunky_png)
       - name: Install libvips
         run: sudo apt-get install -y libvips-dev
 
       - name: Run tests
         run: bundle exec rake test
 
-      # Upload HTML report — renders inline in Actions UI (no download needed)
       - name: Upload screenshot report
         if: failure()
         uses: actions/upload-artifact@v7
@@ -69,8 +170,7 @@ jobs:
           archive: false
           retention-days: 2
 
-      # Upload full report with images (for offline review)
-      - name: Upload full screenshot report
+      - name: Upload full report with images
         if: failure()
         uses: actions/upload-artifact@v7
         with:
@@ -79,66 +179,7 @@ jobs:
           retention-days: 2
 ```
 
-### 3. Or use the reusable action (one line)
-
-Instead of the manual upload steps above, reference our composite action directly:
-
-```yaml
-      - name: Run tests
-        run: bundle exec rake test
-
-      - name: Upload screenshot reports
-        if: failure()
-        uses: snap-diff/snap_diff-capybara/.github/actions/upload-screenshots@master
-        with:
-          name: screenshots
-```
-
-This uploads diffs, Capybara failure screenshots, and the HTML report (inline + full) in one step.
-
-**Inputs:**
-
-| Input | Default | Description |
-|-------|---------|-------------|
-| `name` | (required) | Artifact name prefix |
-| `report-path` | `doc/screenshots` | Path to HTML report directory |
-| `retention-days` | `2` | Days to retain artifacts |
-
-### 4. PR comment with link to report (optional)
-
-Automatically comment on the PR pointing to the artifact. Uses `find-comment` to update existing comments instead of creating duplicates:
-
-```yaml
-      - name: Find existing comment
-        if: failure() && github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'Screenshot diffs detected'
-
-      - name: Comment PR with report link
-        if: failure() && github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            ### Screenshot diffs detected
-            [View report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
-```
-
-**Required:** Add permissions to the job for PR commenting to work:
-
-```yaml
-jobs:
-  test:
-    permissions:
-      contents: read
-      pull-requests: write
-```
+</details>
 
 ## Update Baselines in CI
 
@@ -151,6 +192,9 @@ git commit -m "chore: update screenshot baselines"
 ```
 
 Or add a workflow that maintainers can trigger manually:
+
+<details>
+<summary>Expand update-baselines workflow</summary>
 
 ```yaml
 # .github/workflows/update-baselines.yml
@@ -175,12 +219,10 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: ruby/setup-ruby@v1
+      - uses: snap-diff/snap_diff-capybara/.github/actions/setup-ruby-and-dependencies@master
         with:
-          bundler-cache: true
-
-      - name: Install libvips
-        run: sudo apt-get install -y libvips-dev
+          ruby-version: '4.0'
+          cache-apt-packages: true
 
       - name: Record new baselines
         run: RECORD_SCREENSHOTS=1 bundle exec rake test
@@ -195,14 +237,11 @@ jobs:
           git push
 ```
 
+</details>
+
 **How it works:**
 1. Go to Actions → "Update Screenshot Baselines" → "Run workflow"
 2. Enter the branch name (e.g. your PR branch)
 3. The workflow records new baselines, commits, and pushes
-
-**Safety:**
-- Only maintainers with write access can trigger `workflow_dispatch`
-- The commit uses `git diff --staged --quiet ||` to skip empty commits
-- `GITHUB_TOKEN` pushes don't trigger subsequent CI runs ([by design](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows))
 
 [← Back to README](../README.md)

--- a/test/support/test_helpers.rb
+++ b/test/support/test_helpers.rb
@@ -7,29 +7,20 @@ module TestHelpers
 
   # Common assertions for image comparison tests
   module Assertions
-    # Asserts that a dimension check was called a specific number of times
+    # Asserts that a driver check was called a specific number of times
     # @param driver [Object] The test driver object
+    # @param check_type [Symbol] :dimension_check, :pixel_check, or :difference_region
     # @param times [Integer] The expected number of calls (default: 1)
-    def assert_dimension_check_called(driver, times = 1)
-      assert_equal times, driver.dimension_check_calls.size,
-        "Expected dimension check to be called #{times} time(s)"
+    def assert_driver_check_called(driver, check_type, times = 1)
+      calls = driver.public_send(:"#{check_type}_calls")
+      assert_equal times, calls.size,
+        "Expected #{check_type} to be called #{times} time(s), was called #{calls.size}"
     end
 
-    # Asserts that a pixel check was called a specific number of times
-    # @param driver [Object] The test driver object
-    # @param times [Integer] The expected number of calls (default: 1)
-    def assert_pixel_check_called(driver, times = 1)
-      assert_equal times, driver.pixel_check_calls.size,
-        "Expected pixel check to be called #{times} time(s)"
-    end
-
-    # Asserts that a difference region check was called a specific number of times
-    # @param driver [Object] The test driver object
-    # @param times [Integer] The expected number of calls (default: 1)
-    def assert_difference_region_called(driver, times = 1)
-      assert_equal times, driver.difference_region_calls.size,
-        "Expected difference region check to be called #{times} time(s)"
-    end
+    # Convenience aliases for backward compatibility
+    def assert_dimension_check_called(driver, times = 1) = assert_driver_check_called(driver, :dimension_check, times)
+    def assert_pixel_check_called(driver, times = 1) = assert_driver_check_called(driver, :pixel_check, times)
+    def assert_difference_region_called(driver, times = 1) = assert_driver_check_called(driver, :difference_region, times)
   end
 
   # Common setup methods for test drivers

--- a/test/unit/difference_finder_test.rb
+++ b/test/unit/difference_finder_test.rb
@@ -11,13 +11,14 @@ module Capybara
         include CapybaraScreenshotDiff::DSLStub
         include TestDoubles
 
+        setup do
+          @base_path = TestDoubles::TestPath.new(12345)
+          @new_path = TestDoubles::TestPath.new(54321)
+          @driver = TestDoubles::TestDriver.new(false)
+          setup_test_comparison
+        end
+
         class InitializationTest < self
-          setup do
-            @base_path = TestDoubles::TestPath.new(12345)
-            @new_path = TestDoubles::TestPath.new(54321)
-            @driver = TestDoubles::TestDriver.new(false)
-            setup_test_comparison
-          end
 
           test "#initialize sets driver and options correctly" do
             driver = TestDoubles::TestDriver.new
@@ -32,10 +33,6 @@ module Capybara
 
         class QuickModeTest < self
           setup do
-            @base_path = TestDoubles::TestPath.new(12345)
-            @new_path = TestDoubles::TestPath.new(54321)
-            @driver = TestDoubles::TestDriver.new(false)
-            setup_test_comparison
             @finder = create_finder
           end
 
@@ -76,10 +73,6 @@ module Capybara
 
         class FullModeTest < self
           setup do
-            @base_path = TestDoubles::TestPath.new(12345)
-            @new_path = TestDoubles::TestPath.new(54321)
-            @driver = TestDoubles::TestDriver.new(false)
-            setup_test_comparison
             @finder = create_finder
           end
 

--- a/test/unit/difference_finder_test.rb
+++ b/test/unit/difference_finder_test.rb
@@ -19,7 +19,6 @@ module Capybara
         end
 
         class InitializationTest < self
-
           test "#initialize sets driver and options correctly" do
             driver = TestDoubles::TestDriver.new
             options = {tolerance: 0.05}


### PR DESCRIPTION
## Summary
- **T3**: Hoist duplicated setup from 3 nested classes to parent `DifferenceFinderTest` (−12 lines)
- **T4**: Extract `assert_driver_check_called(driver, check_type, times)` parameterized helper. Old methods kept as one-line aliases for backward compatibility.
- **T6**: Skipped — `assert_same_images` param order already matches Minitest convention

Net: −16 lines, cleaner test structure.

## Test plan
- [x] 224 unit tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor test helpers and difference finder tests to reduce duplication and centralize assertion logic.

Enhancements:
- Hoist shared driver and path setup from nested DifferenceFinderTest subclasses into the parent test class to simplify test initialization.
- Consolidate multiple image comparison assertion helpers into a single parameterized driver check assertion while preserving old method names as thin aliases for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release contains internal test infrastructure improvements with no user-facing changes.

* **Tests**
  * Consolidated several specialized assertion helpers into a single generalized assertion helper while preserving backward-compatible aliases.
  * Simplified test setup by moving shared initialization to a common setup, reducing duplication across nested tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->